### PR TITLE
Dockerfile changes to improve build caching and image build size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,8 @@
+/.devcontainer
+/.github
 /.phpunit.cache
+/database/*.sqlite
+/bootstrap/cache/*
 /node_modules
 /public/build
 /public/hot
@@ -6,6 +10,7 @@
 /storage/*.key
 /storage/pail
 /vendor
+.editorconfig
 .env
 .env.backup
 .env.production
@@ -20,5 +25,3 @@ yarn-error.log
 /.idea
 /.vscode
 /.zed
-/bootstrap/cache/*
-/database/database.sqlite

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,3 +51,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          target: production

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     environment: Testing
 
     steps:
@@ -22,8 +22,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.4
-          tools: composer:v2
+          php-version: 8.3
           coverage: xdebug
 
       - name: Setup Node
@@ -31,9 +30,6 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-
-      - name: Install Node Dependencies
-        run: npm i
 
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader
@@ -45,7 +41,9 @@ jobs:
         run: php artisan key:generate
 
       - name: Build Assets
-        run: npm run build
+        run: |
+          npm ci --no-audit
+          run build
 
       - name: Run Tests
         run: ./vendor/bin/pest --ci --coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Build Assets
         run: |
           npm ci --no-audit
-          run build
+          npm run build
 
       - name: Run Tests
         run: ./vendor/bin/pest --ci --coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,3 @@ COPY --chown=www-data:www-data --from=assets /app/public/build /var/www/html/pub
 
 # Drop back to the www-data user
 USER www-data
-
-# Create the sqlite database
-RUN php -r "file_exists('database/database.sqlite') || touch('database/database.sqlite');"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,48 @@
-FROM bnussbau/serversideup-php:8.3-fpm-nginx-alpine-imagick-chromium
+########################
+# Base Image
+########################
+FROM bnussbau/serversideup-php:8.3-fpm-nginx-alpine-imagick-chromium AS base
 
-USER www-data
+ENV AUTORUN_ENABLED="true"
 
-# Set working directory
+# Switch to the root user so we can do root things
+USER root
+
+# Set the working directory
 WORKDIR /var/www/html
 
-# Create required directories
-RUN mkdir -p storage/logs \
-    && mkdir -p storage/framework/{cache,sessions,views} \
-    && mkdir -p bootstrap/cache \
-    && mkdir -p database
+# Copy the application files
+COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data .env.example .env
 
-COPY --chown=www-data:www-data ./.env.example ./.env
-
-# Install application dependencies
-COPY --chown=www-data:www-data composer.json composer.lock ./
+# Install the composer dependencies
 RUN composer install --no-interaction --prefer-dist --optimize-autoloader
 
-COPY --chown=www-data:www-data package.json package-lock.json ./
-RUN npm ci
+########################
+# Assets Image
+########################
+FROM node:22-alpine AS assets
 
-# Copy application files
-COPY --chown=www-data:www-data . .
-RUN npm run build
+# Copy the application
+COPY --from=base /var/www/html /app
 
-ENV AUTORUN_ENABLED=true
-# Expose port 80
-EXPOSE 8080
+# Set the working directory
+WORKDIR /app
+
+# Install the node dependencies and build the assets
+RUN npm ci --no-audit \
+    && npm run build
+
+########################
+# Production Image
+########################
+FROM base AS production
+
+# Copy the assets from the assets image
+COPY --chown=www-data:www-data --from=assets /app/public/build /var/www/html/public/build
+
+# Drop back to the www-data user
+USER www-data
+
+# Create the sqlite database
+RUN php -r "file_exists('database/database.sqlite') || touch('database/database.sqlite');"


### PR DESCRIPTION
## 📃 Description

Love the work you got going here! This PR improves upon what you've started buy refactoring `Dockerfile` to make use of additional build caching and extracted npm build step to a separate container to cut down on dependencies carried over to the production image.

With the changes the production image also reduces size from `1.83GB` to `1.59GB`.

## 🪵 Changelog

### ➕ Added

- ignore `/.devcontainer` and `/.github` when copying files into the Docker image

### ✏️ Changed

- `docker-build.yml` to use PHP v8.3 which is the same as your build image
- specified `ubuntu-24.04` as the runtime for `docker-build.yml` as this is the latest LTS version for stability
- target `production` build step in `docker-build.yml` as `Dockerfile` was updated to use multi-step builds

## 📷 Screenshots

![image](https://github.com/user-attachments/assets/ad9576e0-43c1-40ed-9a5d-9460671f4373)
