### PR TITLE
Update docker configuration for simpler deployment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=sqlite
-DB_DATABASE=storage/database.sqlite
+DB_DATABASE=database/storage/database.sqlite
 # DB_HOST=127.0.0.1
 # DB_PORT=3306
 # DB_DATABASE=laravel

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,7 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=sqlite
+DB_DATABASE=storage/database.sqlite
 # DB_HOST=127.0.0.1
 # DB_PORT=3306
 # DB_DATABASE=laravel

--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,6 @@ LOG_DEPRECATIONS_CHANNEL=null
 LOG_LEVEL=debug
 
 DB_CONNECTION=sqlite
-DB_DATABASE=database/storage/database.sqlite
 # DB_HOST=127.0.0.1
 # DB_PORT=3306
 # DB_DATABASE=laravel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
             - PHP_OPCACHE_ENABLE=1
             - TRMNL_PROXY_REFRESH_MINUTES=15
         volumes:
-           - database:/var/www/html/database/
-           - storage:/var/www/html/storage
+           - database:/var/www/html/database/storage
+           - storage:/var/www/html/storage/app/public/images/generated
         restart: unless-stopped
         #platform: "linux/arm64/v8"
 volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             #- APP_KEY=
             - PHP_OPCACHE_ENABLE=1
             - TRMNL_PROXY_REFRESH_MINUTES=15
+            - DB_DATABASE=database/storage/database.sqlite
         volumes:
            - database:/var/www/html/database/storage
            - storage:/var/www/html/storage/app/public/images/generated


### PR DESCRIPTION
I've changed .env.example and docker-compose.yml to make deployment (in my opinion) simpler.

Current configuration replaces entire `storage` and `database` directories with empty volumes, requiring user to manually copy required files/directories to the volume.

This is mainly problematic with database as this means the user won't get new migration files with an updated docker image.

The updated configuration uses volumes to store only generated images and moves sqlite database to a separate folder, so migrations and seeders can be left intact.