### PR TITLE
feat: Prefer PNG format for firmware versions 1.5.2 and above

### DIFF
--- a/app/Jobs/GenerateScreenJob.php
+++ b/app/Jobs/GenerateScreenJob.php
@@ -29,10 +29,9 @@ class GenerateScreenJob implements ShouldQueue
      */
     public function handle(): void
     {
-        $newImageUuid = ImageGenerationService::generateImage($this->markup);
+        $newImageUuid = ImageGenerationService::generateImage($this->markup, $this->deviceId);
 
         Device::find($this->deviceId)->update(['current_screen_image' => $newImageUuid]);
-        \Log::info("Device $this->deviceId: updated with new image: $newImageUuid");
 
         if ($this->pluginId) {
             // cache current image

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -17,6 +17,9 @@ class Device extends Model
         'proxy_cloud' => 'boolean',
         'last_log_request' => 'json',
         'proxy_cloud_response' => 'json',
+        'width' => 'integer',
+        'height' => 'integer',
+        'rotate' => 'integer',
     ];
 
     public function getBatteryPercentAttribute()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -25,7 +25,7 @@ class User extends Authenticatable // implements MustVerifyEmail
         'email',
         'password',
         'assign_new_devices',
-        'assign_new_device_id'
+        'assign_new_device_id',
     ];
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -130,7 +130,7 @@ return [
     'force_https' => env('FORCE_HTTPS', false),
     'puppeteer_docker' => env('PUPPETEER_DOCKER', false),
     'puppeteer_mode' => env('PUPPETEER_MODE', 'local'),
-    
+
     /*
     |--------------------------------------------------------------------------
     | Application Version

--- a/database/migrations/2025_05_10_202133_add_rotate_to_devices_table.php
+++ b/database/migrations/2025_05_10_202133_add_rotate_to_devices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->integer('rotate')->nullable()->default(0)->after('width');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('rotate');
+        });
+    }
+};

--- a/resources/views/livewire/device-dashboard.blade.php
+++ b/resources/views/livewire/device-dashboard.blade.php
@@ -59,7 +59,7 @@ new class extends Component {
                                 </flux:callout>
                             @elseif($current_image_path)
                                 <flux:separator class="mt-2 mb-4"/>
-                                <img src="{{ asset($current_image_path) }}" alt="Current Image"/>
+                                <img src="{{ asset($current_image_path) }}" class="max-h-[480px]" alt="Current Image"/>
                             @endif
                         </div>
                     </div>

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -15,6 +15,7 @@ new class extends Component {
     public $default_refresh_interval;
     public $width;
     public $height;
+    public $rotate;
 
     // Playlist properties
     public $playlists;
@@ -39,6 +40,7 @@ new class extends Component {
         $this->default_refresh_interval = $device->default_refresh_interval;
         $this->width = $device->width;
         $this->height = $device->height;
+        $this->rotate = $device->rotate;
         $this->playlists = $device->playlists()->with('items.plugin')->orderBy('created_at')->get();
 
         return view('livewire.devices.configure', [
@@ -65,6 +67,7 @@ new class extends Component {
             'default_refresh_interval' => 'required|integer|min:1',
             'width' => 'required|integer|min:1',
             'height' => 'required|integer|min:1',
+            'rotate' => 'required|integer|min:0|max:359',
         ]);
 
         $this->device->update([
@@ -74,6 +77,7 @@ new class extends Component {
             'default_refresh_interval' => $this->default_refresh_interval,
             'width' => $this->width,
             'height' => $this->height,
+            'rotate' => $this->rotate,
         ]);
 
         Flux::modal('edit-device')->close();
@@ -215,7 +219,7 @@ new class extends Component {
     <div class="flex flex-col gap-6">
         <div
             class="rounded-xl border bg-white dark:bg-stone-950 dark:border-stone-800 text-stone-800 shadow-xs">
-            <div class="px-10 py-8 min-w-lg">
+            <div class="px-10 py-8">
                 @php
                     $current_image_uuid =$device->current_screen_image;
                     if($current_image_uuid) {
@@ -226,7 +230,7 @@ new class extends Component {
                     }
                 @endphp
 
-                <div class="flex items-center justify-between">
+                <div class="flex items-center justify-between gap-4">
                     <flux:tooltip content="Friendly ID: {{$device->friendly_id}}" position="bottom">
                         <h1 class="text-xl font-medium dark:text-zinc-200">{{ $device->name }}</h1>
                     </flux:tooltip>
@@ -282,6 +286,7 @@ new class extends Component {
                         <div class="flex gap-4">
                             <flux:input label="Width (px)" wire:model="width" type="number" />
                             <flux:input label="Height (px)" wire:model="height" type="number"/>
+                            <flux:input label="Rotate °" wire:model="rotate" type="number"/>
                         </div>
                         <flux:input label="Default Refresh Interval (seconds)" wire:model="default_refresh_interval"
                                     type="number"/>
@@ -315,7 +320,7 @@ new class extends Component {
                 @if(!$device->mirror_device_id)
                     @if($current_image_path)
                         <flux:separator class="mt-6 mb-6" text="Next Screen"/>
-                        <img src="{{ asset($current_image_path) }}" alt="Next Image"/>
+                        <img src="{{ asset($current_image_path) }}" class="max-h-[480px]" alt="Next Image"/>
                     @endif
 
                     <flux:separator class="mt-6 mb-6" text="Playlists"/>

--- a/routes/api.php
+++ b/routes/api.php
@@ -82,9 +82,11 @@ Route::get('/display', function (Request $request) {
         $image_path = 'images/setup-logo.bmp';
         $filename = 'setup-logo.bmp';
     } else {
-        if (file_exists(storage_path('app/public/images/generated/'.$image_uuid.'.bmp'))) {
+        if (isset($device->last_firmware_version)
+            && version_compare($device->last_firmware_version, '1.5.2', '<')
+            && Storage::disk('public')->exists('images/generated/'.$image_uuid.'.bmp')) {
             $image_path = 'images/generated/'.$image_uuid.'.bmp';
-        } elseif (file_exists(storage_path('app/public/images/generated/'.$image_uuid.'.png'))) {
+        } elseif (Storage::disk('public')->exists('images/generated/'.$image_uuid.'.png')) {
             $image_path = 'images/generated/'.$image_uuid.'.png';
         } else {
             $image_path = 'images/generated/'.$image_uuid.'.bmp';
@@ -106,7 +108,6 @@ Route::get('/display', function (Request $request) {
     if (config('services.trmnl.image_url_timeout')) {
         $response['image_url_timeout'] = config('services.trmnl.image_url_timeout');
     }
-
     // If update_firmware is true, reset it after returning it, to avoid upgrade loop
     if ($device->update_firmware) {
         $device->resetUpdateFirmwareFlag();
@@ -271,9 +272,11 @@ Route::get('/current_screen', function (Request $request) {
         $image_path = 'images/setup-logo.bmp';
         $filename = 'setup-logo.bmp';
     } else {
-        if (file_exists(storage_path('app/public/images/generated/'.$image_uuid.'.bmp'))) {
+        if (isset($device->last_firmware_version)
+            && version_compare($device->last_firmware_version, '1.5.2', '<')
+            && Storage::disk('public')->exists('images/generated/'.$image_uuid.'.bmp')) {
             $image_path = 'images/generated/'.$image_uuid.'.bmp';
-        } elseif (file_exists(storage_path('app/public/images/generated/'.$image_uuid.'.png'))) {
+        } elseif (Storage::disk('public')->exists('images/generated/'.$image_uuid.'.png')) {
             $image_path = 'images/generated/'.$image_uuid.'.png';
         } else {
             $image_path = 'images/generated/'.$image_uuid.'.bmp';

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -448,9 +448,9 @@ test('authenticated user can fetch their devices', function () {
                     'friendly_id',
                     'mac_address',
                     'battery_voltage',
-                    'rssi'
-                ]
-            ]
+                    'rssi',
+                ],
+            ],
         ])
         ->assertJsonCount(2, 'data');
 
@@ -463,9 +463,9 @@ test('authenticated user can fetch their devices', function () {
                 'friendly_id' => $devices[0]->friendly_id,
                 'mac_address' => $devices[0]->mac_address,
                 'battery_voltage' => 3.72,
-                'rssi' => -63
-            ]
-        ]
+                'rssi' => -63,
+            ],
+        ],
     ]);
 });
 

--- a/tests/Feature/Api/DeviceImageFormatTest.php
+++ b/tests/Feature/Api/DeviceImageFormatTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Models\Device;
+use Illuminate\Support\Facades\Storage;
+
+uses(\Illuminate\Foundation\Testing\RefreshDatabase::class);
+
+beforeEach(function () {
+    Storage::fake('public');
+    Storage::disk('public')->makeDirectory('/images/generated');
+});
+
+test('device with firmware version 1.5.1 gets bmp format', function () {
+    $device = Device::factory()->create([
+        'mac_address' => '00:11:22:33:44:55',
+        'api_key' => 'test-api-key',
+        'current_screen_image' => 'test-image',
+        'last_firmware_version' => '1.5.1',
+    ]);
+
+    // Create both bmp and png files
+    Storage::disk('public')->put('images/generated/test-image.bmp', 'fake bmp content');
+    Storage::disk('public')->put('images/generated/test-image.png', 'fake png content');
+
+    // Test /api/display endpoint
+    $displayResponse = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.5.1',
+    ])->get('/api/display');
+
+    $displayResponse->assertOk()
+        ->assertJson([
+            'filename' => 'test-image.bmp',
+        ]);
+
+    // Test /api/current_screen endpoint
+    $currentScreenResponse = $this->withHeaders([
+        'access-token' => $device->api_key,
+    ])->get('/api/current_screen');
+
+    $currentScreenResponse->assertOk()
+        ->assertJson([
+            'filename' => 'test-image.bmp',
+        ]);
+});
+
+test('device with firmware version 1.5.2 gets png format', function () {
+    $device = Device::factory()->create([
+        'mac_address' => '00:11:22:33:44:55',
+        'api_key' => 'test-api-key',
+        'current_screen_image' => 'test-image',
+        'last_firmware_version' => '1.5.2',
+    ]);
+
+    // Create both bmp and png files
+    Storage::disk('public')->put('images/generated/test-image.png', 'fake bmp content');
+
+    // Test /api/display endpoint
+    $displayResponse = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.5.2',
+    ])->get('/api/display');
+
+    $displayResponse->assertOk()
+        ->assertJson([
+            'filename' => 'test-image.png',
+        ]);
+
+    // Test /api/current_screen endpoint
+    $currentScreenResponse = $this->withHeaders([
+        'access-token' => $device->api_key,
+    ])->get('/api/current_screen');
+
+    $currentScreenResponse->assertOk()
+        ->assertJson([
+            'filename' => 'test-image.png',
+        ]);
+});
+
+test('device falls back to bmp when png does not exist', function () {
+    $device = Device::factory()->create([
+        'mac_address' => '00:11:22:33:44:55',
+        'api_key' => 'test-api-key',
+        'current_screen_image' => 'test-image',
+        'last_firmware_version' => '1.5.2',
+    ]);
+
+    // Create only bmp file
+    Storage::disk('public')->put('images/generated/test-image.bmp', 'fake bmp content');
+
+    // Test /api/display endpoint
+    $displayResponse = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.5.2',
+    ])->get('/api/display');
+
+    $displayResponse->assertOk()
+        ->assertJson([
+            'filename' => 'test-image.bmp',
+        ]);
+
+    // Test /api/current_screen endpoint
+    $currentScreenResponse = $this->withHeaders([
+        'access-token' => $device->api_key,
+    ])->get('/api/current_screen');
+
+    $currentScreenResponse->assertOk()
+        ->assertJson([
+            'filename' => 'test-image.bmp',
+        ]);
+});

--- a/tests/Feature/GenerateScreenJobTest.php
+++ b/tests/Feature/GenerateScreenJobTest.php
@@ -23,7 +23,6 @@ test('it generates screen images and updates device', function () {
     // Assert both PNG and BMP files were created
     $uuid = $device->current_screen_image;
     Storage::disk('public')->assertExists("/images/generated/{$uuid}.png");
-    Storage::disk('public')->assertExists("/images/generated/{$uuid}.bmp");
 })->skipOnGitHubActions();
 
 test('it cleans up unused images', function () {


### PR DESCRIPTION
Since firmware version 1.5.2, the default image format is PNG with the following specifications:
PNG 800x480 800x480+0+0 8-bit Grayscale Gray 2c.

What’s in this PR
* Adds support for PNG image format
* Enables scaling to custom device dimensions
* Supports image rotation