### PR TITLE
feat: support additional devices (e.g. Kindle)

### DIFF
--- a/app/Enums/ImageFormat.php
+++ b/app/Enums/ImageFormat.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Enums;
+
+enum ImageFormat: string
+{
+    case AUTO = 'auto';
+    case PNG_8BIT_GRAYSCALE = 'png_8bit_grayscale';
+    case BMP3_1BIT_SRGB = 'bmp3_1bit_srgb';
+    case PNG_8BIT_256C = 'png_8bit_256c';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::AUTO => 'Auto',
+            self::PNG_8BIT_GRAYSCALE => 'PNG 8-bit Grayscale Gray 2c',
+            self::BMP3_1BIT_SRGB => 'BMP3 1-bit sRGB 2c',
+            self::PNG_8BIT_256C => 'PNG 8-bit Grayscale Gray 256c',
+        };
+    }
+}

--- a/app/Services/ImageGenerationService.php
+++ b/app/Services/ImageGenerationService.php
@@ -115,4 +115,21 @@ class ImageGenerationService
             }
         }
     }
+
+    public static function resetIfNotCacheable(?Plugin $plugin): void
+    {
+        if ($plugin?->id) {
+            if (
+                Device::query()
+                    ->where('width', '!=', 800)
+                    ->orWhere('height', '!=', 480)
+                    ->orWhere('rotate', '!=', 0)
+                    ->exists()
+            ) {
+                // TODO cache image per device
+                $plugin->update(['current_image' => null]);
+                \Log::debug('Skip cache as devices with other dimensions exist');
+            }
+        }
+    }
 }

--- a/database/migrations/2025_05_13_154942_add_image_format_to_devices_table.php
+++ b/database/migrations/2025_05_13_154942_add_image_format_to_devices_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->string('image_format')->default('auto')->after('rotate');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropColumn('image_format');
+        });
+    }
+};

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -16,6 +16,7 @@ new class extends Component {
     public $width;
     public $height;
     public $rotate;
+    public $image_format;
 
     // Playlist properties
     public $playlists;
@@ -41,6 +42,7 @@ new class extends Component {
         $this->width = $device->width;
         $this->height = $device->height;
         $this->rotate = $device->rotate;
+        $this->image_format = $device->image_format;
         $this->playlists = $device->playlists()->with('items.plugin')->orderBy('created_at')->get();
 
         return view('livewire.devices.configure', [
@@ -68,6 +70,7 @@ new class extends Component {
             'width' => 'required|integer|min:1',
             'height' => 'required|integer|min:1',
             'rotate' => 'required|integer|min:0|max:359',
+            'image_format' => 'required|string',
         ]);
 
         $this->device->update([
@@ -78,6 +81,7 @@ new class extends Component {
             'width' => $this->width,
             'height' => $this->height,
             'rotate' => $this->rotate,
+            'image_format' => $this->image_format,
         ]);
 
         Flux::modal('edit-device')->close();
@@ -288,6 +292,11 @@ new class extends Component {
                             <flux:input label="Height (px)" wire:model="height" type="number"/>
                             <flux:input label="Rotate °" wire:model="rotate" type="number"/>
                         </div>
+                        <flux:select label="Image Format" wire:model="image_format">
+                            @foreach(\App\Enums\ImageFormat::cases() as $format)
+                                <flux:select.option value="{{ $format->value }}">{{$format->label()}}</flux:select.option>
+                            @endforeach
+                        </flux:select>
                         <flux:input label="Default Refresh Interval (seconds)" wire:model="default_refresh_interval"
                                     type="number"/>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,7 @@
 use App\Jobs\GenerateScreenJob;
 use App\Models\Device;
 use App\Models\User;
+use App\Services\ImageGenerationService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
@@ -52,6 +53,9 @@ Route::get('/display', function (Request $request) {
             if ($playlistItem) {
                 $refreshTimeOverride = $playlistItem->playlist()->first()->refresh_time;
                 $plugin = $playlistItem->plugin;
+
+                // Reset cache if Devices with different dimensions exist
+                ImageGenerationService::resetIfNotCacheable($plugin);
 
                 // Check and update stale data if needed
                 if ($plugin->isDataStale() || $plugin->current_image == null) {


### PR DESCRIPTION
This PR adds more flexibility in terms of device dimensions, rotation and image format to support more devices (like [trmnl-kindle](https://github.com/usetrmnl/trmnl-kindle/tree/main/zip_example)).

Tested working with Kindle 10th Gen and these Device Settings:

* Width (px): 1400
* Height (px): 1100
* Rotate (°): 90
* Image Format: PNG 8-bit Grayscale Gray 256c

Instructions to modify the Kindle: [https://github.com/usetrmnl/trmnl-kindle](https://github.com/usetrmnl/trmnl-kindle)

Note: BYOS Laravel requires a mac adress in the header when calling the `api/display` port. Be sure to adapt the curl command like this

```sh
# 2) Fetch JSON metadata
  RESPONSE="$(
    curl -s \
      -H "access-token: $API_KEY" \
      -H "id: $MAC_ADDRESS" \                  # add a Mac Address (can be fake or real)
      -H "battery-voltage: $BATTERY_VOLTAGE" \
      -H "rssi: $RSSI" \
      -A "$USER_AGENT" \
      "${BASE_URL}/api/display"
  )"

```
