### PR TITLE
feat(#17): enable standalone firmware updates

### DIFF
--- a/app/Console/Commands/FirmwareCheckCommand.php
+++ b/app/Console/Commands/FirmwareCheckCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Jobs\FirmwarePollJob;
+use App\Models\Firmware;
+use Illuminate\Console\Command;
+use function Laravel\Prompts\spin;
+use function Laravel\Prompts\table;
+
+class FirmwareCheckCommand extends Command
+{
+    protected $signature = 'trmnl:firmware:check {--download : Download the latest firmware if available}';
+
+    protected $description = 'Checks for the latest firmware and downloads it if flag --download is passed.';
+
+    public function handle(): void
+    {
+        spin(
+            callback: fn () => FirmwarePollJob::dispatchSync(download: $this->option('download')),
+            message: 'Checking for latest firmware...'
+        );
+
+        $latestFirmware = Firmware::getLatest();
+        if ($latestFirmware) {
+            table(
+                rows: [
+                    ['Latest Version', $latestFirmware->version_tag],
+                    ['Download URL', $latestFirmware->url],
+                    ['Storage Location', $latestFirmware->storage_location],
+                ]
+            );
+        } else {
+            $this->error('No firmware found.');
+        }
+    }
+}

--- a/app/Console/Commands/FirmwareUpdateCommand.php
+++ b/app/Console/Commands/FirmwareUpdateCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Device;
+use App\Models\Firmware;
+use Illuminate\Console\Command;
+
+use function Laravel\Prompts\multiselect;
+use function Laravel\Prompts\select;
+
+class FirmwareUpdateCommand extends Command
+{
+    protected $signature = 'trmnl:firmware:update';
+
+    protected $description = 'Command description';
+
+    public function handle(): void
+    {
+
+        $checkFirmware = select(
+            label: 'Check for new firmware?',
+            options: [
+                'check' => 'Check. Devices will download binary from the original source.',
+                'download' => 'Check & Download. Devices will download binary from BYOS.',
+                'no' => 'Do not check.',
+            ],
+        );
+
+        if ($checkFirmware !== 'no') {
+            $this->call('trmnl:firmware:check', [
+                '--download' => $checkFirmware === 'download',
+            ]);
+        }
+
+        $firmwareVersion = select(
+            label: 'Update to which version?',
+            options: Firmware::pluck('version_tag', 'id')
+        );
+
+        $devices = multiselect(
+            label: 'Which devices should be updated?',
+            options: [
+                'all' => 'ALL Devices',
+                ...Device::all()->mapWithKeys(function ($device) {
+                    // without _ returns index
+                    return ["_$device->id" => "$device->name (Current version: $device->last_firmware_version)"];
+                })->toArray()
+            ],
+            scroll: 10
+        );
+
+
+
+        if (empty($devices)) {
+            $this->error('No devices selected. Aborting.');
+            return;
+        }
+
+        if (in_array('all', $devices)) {
+            $devices = Device::pluck('id')->toArray();
+        } else {
+            $devices = array_map(function($selected) {
+                return (int) str_replace('_', '', $selected);
+            }, $devices);
+        }
+
+
+        foreach ($devices as $deviceId) {
+            Device::find($deviceId)->update(['update_firmware_id' => $firmwareVersion]);
+
+            $this->info("Device with id [$deviceId] will update firmware on next request.");
+        }
+    }
+}

--- a/app/Jobs/FirmwareDownloadJob.php
+++ b/app/Jobs/FirmwareDownloadJob.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Firmware;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+
+class FirmwareDownloadJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    private Firmware $firmware;
+
+    public function __construct(Firmware $firmware)
+    {
+        $this->firmware = $firmware;
+    }
+
+    public function handle(): void
+    {
+        if (! Storage::disk('public')->exists('firmwares')) {
+            Storage::disk('public')->makeDirectory('firmwares');
+        }
+
+        try {
+            $filename = "FW{$this->firmware->version_tag}.bin";
+            Http::sink(storage_path("app/public/firmwares/$filename"))
+                ->get($this->firmware->url);
+
+            $this->firmware->update([
+                'storage_location' => "firmwares/$filename",
+            ]);
+        } catch (ConnectionException $e) {
+            Log::error('Firmware download failed: '.$e->getMessage());
+        } catch (\Exception $e) {
+            Log::error('An unexpected error occurred: '.$e->getMessage());
+        }
+    }
+} 

--- a/app/Jobs/FirmwarePollJob.php
+++ b/app/Jobs/FirmwarePollJob.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Firmware;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Http;
+
+class FirmwarePollJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    private bool $download;
+
+    public function __construct(bool $download = false)
+    {
+        $this->download = $download;
+    }
+
+    public function handle(): void
+    {
+        try {
+            $response = Http::get('https://usetrmnl.com/api/firmware/latest')->json();
+
+            if (!is_array($response) || !isset($response['version']) || !isset($response['url'])) {
+                \Log::error('Invalid firmware response format received');
+                return;
+            }
+
+            $latestFirmware = Firmware::updateOrCreate(
+                ['version_tag' => $response['version']],
+                [
+                    'url' => $response['url'],
+                    'latest' => true,
+                ]
+            );
+
+            Firmware::where('id', '!=', $latestFirmware->id)->update(['latest' => false]);
+
+            if ($this->download && $latestFirmware->url && $latestFirmware->storage_location === null) {
+                FirmwareDownloadJob::dispatchSync($latestFirmware);
+            }
+
+        } catch (ConnectionException $e) {
+            \Log::error('Firmware download failed: '.$e->getMessage());
+        } catch (\Exception $e) {
+            \Log::error('Unexpected error in firmware polling: '.$e->getMessage());
+        }
+    }
+}

--- a/app/Models/Firmware.php
+++ b/app/Models/Firmware.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Firmware extends Model
+{
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    protected function casts(): array
+    {
+        return [
+            'latest' => 'boolean',
+        ];
+    }
+
+    public static function getLatest(): ?self
+    {
+        return self::where('latest', true)->first();
+    }
+}

--- a/database/factories/FirmwareFactory.php
+++ b/database/factories/FirmwareFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Firmware;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+class FirmwareFactory extends Factory
+{
+    protected $model = Firmware::class;
+
+    public function definition(): array
+    {
+        return [
+            'version_tag' => $this->faker->word(),
+            'url' => $this->faker->url(),
+            'latest' => $this->faker->boolean(),
+            'storage_location' => $this->faker->word(),
+            'created_at' => Carbon::now(),
+            'updated_at' => Carbon::now(),
+        ];
+    }
+}

--- a/database/migrations/2025_05_28_232528_create_firmware_table.php
+++ b/database/migrations/2025_05_28_232528_create_firmware_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('firmware', function (Blueprint $table) {
+            $table->id();
+            $table->string('version_tag');
+            $table->string('url')->nullable();
+            $table->boolean('latest')->default(false);
+            $table->string('storage_location')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('firmware');
+    }
+};

--- a/database/migrations/2025_05_29_010428_add_update_firmware_id_to_devices_table.php
+++ b/database/migrations/2025_05_29_010428_add_update_firmware_id_to_devices_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->foreignId('update_firmware_id')->nullable()->constrained('firmware')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('devices', function (Blueprint $table) {
+            $table->dropForeign(['update_firmware_id']);
+            $table->dropColumn('update_firmware_id');
+        });
+    }
+};

--- a/resources/views/recipes/weather.blade.php
+++ b/resources/views/recipes/weather.blade.php
@@ -3,7 +3,7 @@
     <x-trmnl::layout class="layout--col gap--space-between">
         <div class="grid" style="gap: 9px;">
             <div class="row row--center col--span-3 col--end">
-                <img class="weather-image" style="max-height: 150px; margin:auto;" src="https://usetrmnl.com/images/weather/wi-thermometer.svg">
+                <img class="weather-image" style="max-height: 150px; margin:auto;" src="https://usetrmnl.com/images/plugins/weather/wi-thermometer.svg">
             </div>
             <div class="col col--span-3 col--end">
                 <div class="item h--full">

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,11 @@
 <?php
 
 use App\Jobs\FetchProxyCloudResponses;
+use App\Jobs\FirmwarePollJob;
 
 Schedule::job(FetchProxyCloudResponses::class, [])->cron(
     config('services.trmnl.proxy_refresh_cron') ? config('services.trmnl.proxy_refresh_cron') :
         sprintf('*/%s * * * *', intval(config('services.trmnl.proxy_refresh_minutes', 15)))
 );
+
+Schedule::job(FirmwarePollJob::class)->daily();

--- a/tests/Feature/Jobs/FirmwareDownloadJobTest.php
+++ b/tests/Feature/Jobs/FirmwareDownloadJobTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use App\Jobs\FirmwareDownloadJob;
+use App\Models\Firmware;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+
+beforeEach(function () {
+    Storage::fake('public');
+    Storage::disk('public')->makeDirectory('/firmwares');
+});
+
+test('it creates firmwares directory if it does not exist', function () {
+    $firmware = Firmware::factory()->create([
+        'url' => 'https://example.com/firmware.bin',
+        'version_tag' => '1.0.0',
+    ]);
+
+    (new FirmwareDownloadJob($firmware))->handle();
+
+    expect(Storage::disk('public')->exists('firmwares'))->toBeTrue();
+});
+
+test('it downloads firmware and updates storage location', function () {
+    Http::fake([
+        'https://example.com/firmware.bin' => Http::response('fake firmware content', 200),
+    ]);
+
+    $firmware = Firmware::factory()->create([
+        'url' => 'https://example.com/firmware.bin',
+        'version_tag' => '1.0.0',
+    ]);
+
+    (new FirmwareDownloadJob($firmware))->handle();
+
+    expect($firmware->fresh()->storage_location)->toBe('firmwares/FW1.0.0.bin');
+});

--- a/tests/Feature/Jobs/FirmwarePollJobTest.php
+++ b/tests/Feature/Jobs/FirmwarePollJobTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Jobs\FirmwarePollJob;
+use App\Models\Firmware;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+test('it creates new firmware record when polling', function () {
+    Http::fake([
+        'usetrmnl.com/api/firmware/latest' => Http::response([
+            'version' => '1.0.0',
+            'url' => 'https://example.com/firmware.bin'
+        ], 200)
+    ]);
+
+    (new FirmwarePollJob())->handle();
+
+    expect(Firmware::where('version_tag', '1.0.0')->exists())->toBeTrue()
+        ->and(Firmware::where('version_tag', '1.0.0')->first())
+        ->url->toBe('https://example.com/firmware.bin')
+        ->latest->toBeTrue();
+});
+
+test('it updates existing firmware record when polling', function () {
+    $existingFirmware = Firmware::factory()->create([
+        'version_tag' => '1.0.0',
+        'url' => 'https://old-url.com/firmware.bin',
+        'latest' => true
+    ]);
+
+    Http::fake([
+        'usetrmnl.com/api/firmware/latest' => Http::response([
+            'version' => '1.0.0',
+            'url' => 'https://new-url.com/firmware.bin'
+        ], 200)
+    ]);
+
+    (new FirmwarePollJob())->handle();
+
+    expect($existingFirmware->fresh())
+        ->url->toBe('https://new-url.com/firmware.bin')
+        ->latest->toBeTrue();
+});
+
+test('it marks previous firmware as not latest when new version is found', function () {
+    $oldFirmware = Firmware::factory()->create([
+        'version_tag' => '1.0.0',
+        'latest' => true
+    ]);
+
+    Http::fake([
+        'usetrmnl.com/api/firmware/latest' => Http::response([
+            'version' => '1.1.0',
+            'url' => 'https://example.com/firmware.bin'
+        ], 200)
+    ]);
+
+    (new FirmwarePollJob())->handle();
+
+    expect($oldFirmware->fresh()->latest)->toBeFalse()
+        ->and(Firmware::where('version_tag', '1.1.0')->first()->latest)->toBeTrue();
+});
+
+test('it handles connection exception gracefully', function () {
+    Http::fake([
+        'usetrmnl.com/api/firmware/latest' => function () {
+            throw new ConnectionException('Connection failed');
+        }
+    ]);
+
+    (new FirmwarePollJob())->handle();
+
+    // Verify no firmware records were created
+    expect(Firmware::count())->toBe(0);
+});
+
+test('it handles invalid response gracefully', function () {
+    Http::fake([
+        'usetrmnl.com/api/firmware/latest' => Http::response(null, 200)
+    ]);
+
+    (new FirmwarePollJob())->handle();
+
+    // Verify no firmware records were created
+    expect(Firmware::count())->toBe(0);
+});
+
+test('it handles missing version in response gracefully', function () {
+    Http::fake([
+        'usetrmnl.com/api/firmware/latest' => Http::response([
+            'url' => 'https://example.com/firmware.bin'
+        ], 200)
+    ]);
+
+    (new FirmwarePollJob())->handle();
+
+    // Verify no firmware records were created
+    expect(Firmware::count())->toBe(0);
+});
+
+test('it handles missing url in response gracefully', function () {
+    Http::fake([
+        'usetrmnl.com/api/firmware/latest' => Http::response([
+            'version' => '1.0.0'
+        ], 200)
+    ]);
+
+    (new FirmwarePollJob())->handle();
+
+    // Verify no firmware records were created
+    expect(Firmware::count())->toBe(0);
+});


### PR DESCRIPTION
# Update Firmware

## Polling Job
Job runs daily to check for new firmware version.
Run command to check interactively 
```sh
php artisan trmnl:firmware:check 
# or to check & download
php artisan trmnl:firmware:check --download
```

## Batch Update Command

Run command in terminal to batch update all / selected devices
```sh
php artisan trmnl:firmware:update
```

![image](https://github.com/user-attachments/assets/2610ce8e-c96e-4538-ab0a-0154f353f59c)

## Update UI
Devices > Detail Page > … > Update Firmware

![image](https://github.com/user-attachments/assets/1febb56e-c1f9-4723-893c-6fa2a37161dc)

![image](https://github.com/user-attachments/assets/b861db5b-cd40-4dac-a864-7e8482258edd)

