### PR TITLE
fix(#49): allow long polling URL for plugins

### DIFF
--- a/database/migrations/2025_06_20_163742_allow_long_polling_url.php
+++ b/database/migrations/2025_06_20_163742_allow_long_polling_url.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table("plugins", function (Blueprint $table) {
+            $table->string('polling_url', 1024)->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table("plugins", function (Blueprint $table) {
+            // old default string length value in Illuminate
+            $table->string('polling_url', 255)->nullable()->change();
+        });
+    }
+};


### PR DESCRIPTION
Adds a migration to raise the maximum length of the polling URL for plugins to 1024 characters. This prevents the error/unintentional behavior described in #49 from happening.