### PR TITLE
fix: wait for idle network before taking screenshots

### DIFF
--- a/app/Services/ImageGenerationService.php
+++ b/app/Services/ImageGenerationService.php
@@ -30,6 +30,7 @@ class ImageGenerationService
             try {
                 BrowsershotLambda::html($markup)
                     ->windowSize(800, 480)
+                    ->waitUntilNetworkIdle()
                     ->save($pngPath);
             } catch (Exception $e) {
                 Log::error('Failed to generate PNG: '.$e->getMessage());
@@ -40,6 +41,7 @@ class ImageGenerationService
                 Browsershot::html($markup)
                     ->setOption('args', config('app.puppeteer_docker') ? ['--no-sandbox', '--disable-setuid-sandbox', '--disable-gpu'] : [])
                     ->windowSize(800, 480)
+                    ->waitUntilNetworkIdle()
                     ->save($pngPath);
             } catch (Exception $e) {
                 Log::error('Failed to generate PNG: '.$e->getMessage());


### PR DESCRIPTION
I noticed that, for one of my recipes, about 50% of the time, fonts and images would not load:

![2025-07-07_20-49](https://github.com/user-attachments/assets/faa3e32f-4a2c-4c96-b3b7-cee46b9d60eb)

There appears to be a race condition where the screenshot is taken before the HTTP requests finish. I saw that Browsershot has a [`waitUntilNetworkIdle` function](https://spatie.be/docs/browsershot/v4/usage/creating-images#content-waiting-for-lazy-loaded-resources) for this exact purpose, with which I've been able to successfully fix this issue.

![2025-07-07_20-54](https://github.com/user-attachments/assets/6a7e997d-20b1-4bb8-9465-f7a90234dfaf)

Here's a small PR with that fix.