### PR TITLE
Allow plain text response for plugin data polling

### DIFF
--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -243,7 +243,7 @@ class Plugin extends Model
             }
             
             // Response doesn't seem to be JSON, wrap the response body text as a JSON object
-            return ['text' => $httpResponse->body()];
+            return ['data' => $httpResponse->body()];
         } catch (Exception $e) {
             Log::warning('Failed to parse JSON response: '.$e->getMessage());
 

--- a/tests/Feature/PluginXmlResponseTest.php
+++ b/tests/Feature/PluginXmlResponseTest.php
@@ -113,7 +113,7 @@ test('plugin wraps plain text response body as JSON', function (): void {
     $plugin->refresh();
 
     expect($plugin->data_payload)->toBe([
-        'text' => 'Lorem ipsum dolor sit amet',
+        'data' => 'Lorem ipsum dolor sit amet',
     ]);
 });
 


### PR DESCRIPTION
If the API response body from plugin polling is neither json parsable nor xml, wrap the body as a json object.

<img width="1236" height="883" alt="image" src="https://github.com/user-attachments/assets/1738c545-e549-4c09-8d55-0dd78ee47b20" />
