### PR TITLE
Add maximum_compatibility boolean to devices to address redraw issues with certain hardware

### DIFF
--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -42,6 +42,7 @@ class Device extends Model
         'sleep_mode_to' => 'datetime:H:i',
         'special_function' => 'string',
         'pause_until' => 'datetime',
+        'maximum_compatibility' => 'boolean',
     ];
 
     public function getBatteryPercentAttribute(): int|float

--- a/database/migrations/2026_02_01_121714_add_maximum_compatibility_to_devices_table.php
+++ b/database/migrations/2026_02_01_121714_add_maximum_compatibility_to_devices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table("devices", function (Blueprint $table): void {
+            $table->boolean("maximum_compatibility")->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table("devices", function (Blueprint $table): void {
+            $table->dropColumn("maximum_compatibility");
+        });
+    }
+};

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -31,6 +31,9 @@ new class extends Component
 
     public $device_model_id;
 
+    // Signal to device to use high compatibility approaches when redrawing content
+    public $maximum_compatibility = false;
+
     // Sleep mode and special function
     public $sleep_mode_enabled = false;
 
@@ -81,6 +84,7 @@ new class extends Component
         $this->rotate = $device->rotate;
         $this->image_format = $device->image_format;
         $this->device_model_id = $device->device_model_id;
+        $this->maximum_compatibility = $device->maximum_compatibility;
         $this->deviceModels = DeviceModel::orderBy('label')->get()->sortBy(function ($deviceModel) {
             // Put TRMNL models at the top, then sort alphabetically within each group
             $isTrmnl = str_starts_with($deviceModel->label, 'TRMNL');
@@ -141,6 +145,7 @@ new class extends Component
             'rotate' => 'required|integer|min:0|max:359',
             'image_format' => 'required|string',
             'device_model_id' => 'nullable|exists:device_models,id',
+            'maximum_compatibility' => 'boolean',
             'sleep_mode_enabled' => 'boolean',
             'sleep_mode_from' => 'nullable|date_format:H:i',
             'sleep_mode_to' => 'nullable|date_format:H:i',
@@ -160,6 +165,7 @@ new class extends Component
             'rotate' => $this->rotate,
             'image_format' => $this->image_format,
             'device_model_id' => $deviceModelId,
+            'maximum_compatibility' => $this->maximum_compatibility,
             'sleep_mode_enabled' => $this->sleep_mode_enabled,
             'sleep_mode_from' => $this->sleep_mode_from,
             'sleep_mode_to' => $this->sleep_mode_to,
@@ -426,6 +432,8 @@ new class extends Component
                                 </flux:select.option>
                             @endforeach
                         </flux:select>
+
+                        <flux:checkbox wire:model="maximum_compatibility" label="Maximum Compatibility" description="Enable if experiencing display issues" />
 
                         @if(empty($device_model_id))
                             <flux:separator class="my-4" text="Advanced Device Settings" />
@@ -787,4 +795,3 @@ new class extends Component
         </div>
     </div>
 </div>
-

--- a/routes/api.php
+++ b/routes/api.php
@@ -194,6 +194,7 @@ Route::get('/display', function (Request $request) {
         'update_firmware' => $device->update_firmware,
         'firmware_url' => $device->firmware_url,
         'special_function' => $device->special_function ?? 'sleep',
+        'maximum_compatibility' => $device->maximum_compatibility,
     ];
 
     if (config('services.trmnl.image_url_timeout')) {

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -45,6 +45,7 @@ test('device can fetch display data with valid credentials', function (): void {
             'update_firmware' => false,
             'firmware_url' => null,
             'special_function' => 'sleep',
+            'maximum_compatibility' => false,
         ]);
 
     expect($device->fresh())
@@ -93,6 +94,27 @@ test('display endpoint omits image_url_timeout when not configured', function ()
 
     $response->assertOk()
         ->assertJsonMissing(['image_url_timeout']);
+});
+
+test('display endpoint includes maximum_compatibility value when true for device', function (): void {
+    $device = Device::factory()->create([
+        'mac_address' => '00:11:22:33:44:55',
+        'api_key' => 'test-api-key',
+        'maximum_compatibility' => true
+    ]);
+
+    $response = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $response->assertOk()
+        ->assertJson([
+            'maximum_compatibility' => true,
+        ]);
 });
 
 test('new device is auto-assigned to user with auto-assign enabled', function (): void {


### PR DESCRIPTION
This adds a `maximum_compatibility` field to devices and returns it via `/api/display`, to allow devices with firmware 1.6.2 to use a version of the redraw logic that works better with some hardware.

I've only added tests for the display endpoint, as I didn't spot existing granular test coverage of the UI; happy to add if that's preferred, of course.

This resolves #178.