### PR TITLE
chore: remove mac_address param web mirror trmnl client

### DIFF
--- a/public/mirror/index.html
+++ b/public/mirror/index.html
@@ -39,7 +39,6 @@
         var data = trmnl.getSettings();
         trmnl.ui.apiKeyInput.value = data.api_key || "";
         trmnl.ui.baseURLInput.value = data.base_url || "";
-        trmnl.ui.macAddressInput.value = data.mac_address || "";
         trmnl.ui.displayModeSelect.value = data.display_mode || "";
 
         trmnl.ui.setup.style.display = "flex";
@@ -50,7 +49,6 @@
 
         var apiKey = trmnl.ui.apiKeyInput.value;
         var baseURL = trmnl.ui.baseURLInput.value;
-        var macAddress = trmnl.ui.macAddressInput.value;
         var displayMode = trmnl.ui.displayModeSelect.value;
 
         if (!apiKey) {
@@ -60,7 +58,6 @@
         trmnl.saveSettings({
           api_key: apiKey,
           base_url: baseURL,
-          mac_address: macAddress,
           display_mode: displayMode
         });
 
@@ -84,7 +81,6 @@
         var apiKey = setup.api_key;
         var displayMode = setup.display_mode;
         var baseURL = setup.base_url || "https://your-byos-trmnl.com";
-        var macAddress = setup.mac_address || "00:00:00:00:00:01";
 
         document.body.classList.remove("dark", "night")
         if (displayMode) {
@@ -92,8 +88,7 @@
         }
 
         var headers = {
-          "Access-Token": apiKey,
-          "id": macAddress
+          "Access-Token": apiKey
         };
 
         var url = baseURL + "/api/display";
@@ -210,10 +205,6 @@
             hasOverrides = true;
           }
 
-          if (key === "mac_address" && value) {
-            newSettings.mac_address = value;
-            hasOverrides = true;
-          }
         }
 
         if (hasOverrides) {
@@ -274,7 +265,6 @@
         // settings
         trmnl.ui.apiKeyInput = document.getElementById("api_key");
         trmnl.ui.baseURLInput = document.getElementById("base_url");
-        trmnl.ui.macAddressInput = document.getElementById("mac_address");
         trmnl.ui.displayModeSelect = document.getElementById("display_mode");
         trmnl.ui.setup = document.getElementById("setup");
 
@@ -469,12 +459,6 @@
       <img src="/mirror/assets/logo--brand.svg" alt="TRMNL Logo" />
 
       <form onsubmit="return trmnl.saveSetup(event)">
-        <fieldset>
-          <label for="mac_address">Device MAC Address</label>
-          <input name="mac_address" id="mac_address" type="text" placeholder="00:00:00:00:00:01" class="form-control"
-            required />
-        </fieldset>
-
         <fieldset>
           <label for="api_key">Device API Key</label>
           <input name="api_key" id="api_key" type="text" placeholder="API Key" class="form-control" required />

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -559,7 +559,7 @@ new class extends Component
 
                 <flux:modal name="mirror-url" class="md:w-96">
                     @php
-                        $mirrorUrl = url('/mirror/index.html') . '?mac_address=' . urlencode($device->mac_address) . '&api_key=' . urlencode($device->api_key);
+                        $mirrorUrl = url('/mirror/index.html') . '?api_key=' . urlencode($device->api_key);
                     @endphp
 
                     <div class="space-y-6">


### PR DESCRIPTION
remove mac_address param from web mirror client and ui link
related to  fix(#158): do not require ID header on /display endpoint