### PR TITLE
Correctly set content type when specified in polling headers

### DIFF
--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -192,8 +192,12 @@ class Plugin extends Model
             $httpRequest = Http::withHeaders($headers);
 
             if ($this->polling_verb === 'post' && $this->polling_body) {
+                $contentType = (array_key_exists('Content-Type', $headers))
+                    ? $headers['Content-Type']
+                    : 'application/json';
+
                 $resolvedBody = $this->resolveLiquidVariables($this->polling_body);
-                $httpRequest = $httpRequest->withBody($resolvedBody);
+                $httpRequest = $httpRequest->withBody($resolvedBody, $contentType);
             }
 
             try {


### PR DESCRIPTION
This changes the polling body setting logic to use the 2-argument form, deriving the content type from the specified headers, or using `application/json` if none is set.

This ensure that we can avoid all outgoing requests having a `content-type` of `application/json`.

This resolves #184.