### PR TITLE
Handle XML namespaces

### DIFF
--- a/app/Services/Plugin/Parsers/XmlResponseParser.php
+++ b/app/Services/Plugin/Parsers/XmlResponseParser.php
@@ -23,7 +23,7 @@ class XmlResponseParser implements ResponseParser
                 throw new Exception('Invalid XML content');
             }
 
-            return ['rss' => $this->xmlToArray($xml)];
+            return [$xml->getName() => $this->xmlToArray($xml)];
         } catch (Exception $exception) {
             Log::warning('Failed to parse XML response: '.$exception->getMessage());
 

--- a/tests/Feature/PluginResponseTest.php
+++ b/tests/Feature/PluginResponseTest.php
@@ -95,9 +95,9 @@ test('plugin parses namespaces XML responses and wraps under root key', function
 
     $plugin->refresh();
 
-    expect($plugin->data_payload)->toHaveKey('rss');
-    expect($plugin->data_payload['rss'])->toHaveKey('icing');
-    expect($plugin->data_payload['rss']['icing']['ontop'])->toBe('Cherry');
+    expect($plugin->data_payload)->toHaveKey('cake');
+    expect($plugin->data_payload['cake'])->toHaveKey('icing');
+    expect($plugin->data_payload['cake']['icing']['ontop'])->toBe('Cherry');
 });
 
 test('plugin parses JSON-parsable response body as JSON', function (): void {
@@ -191,8 +191,8 @@ test('plugin handles multiple URLs with mixed content types', function (): void 
     expect($plugin->data_payload['IDX_0'])->toBe($jsonResponse);
 
     // Second URL should be XML wrapped under rss
-    expect($plugin->data_payload['IDX_1'])->toHaveKey('rss');
-    expect($plugin->data_payload['IDX_1']['rss']['item'])->toBe('XML Data');
+    expect($plugin->data_payload['IDX_1'])->toHaveKey('root');
+    expect($plugin->data_payload['IDX_1']['root']['item'])->toBe('XML Data');
 });
 
 test('plugin handles POST requests with XML responses', function (): void {
@@ -213,11 +213,11 @@ test('plugin handles POST requests with XML responses', function (): void {
 
     $plugin->refresh();
 
-    expect($plugin->data_payload)->toHaveKey('rss');
-    expect($plugin->data_payload['rss'])->toHaveKey('status');
-    expect($plugin->data_payload['rss'])->toHaveKey('data');
-    expect($plugin->data_payload['rss']['status'])->toBe('success');
-    expect($plugin->data_payload['rss']['data'])->toBe('test');
+    expect($plugin->data_payload)->toHaveKey('response');
+    expect($plugin->data_payload['response'])->toHaveKey('status');
+    expect($plugin->data_payload['response'])->toHaveKey('data');
+    expect($plugin->data_payload['response']['status'])->toBe('success');
+    expect($plugin->data_payload['response']['data'])->toBe('test');
 });
 
 test('plugin parses iCal responses and filters to recent window', function (): void {


### PR DESCRIPTION
This changes the plugin response XML parsing logic to check if namespaces are present in the response and, if so, strip them and re-parse the response. This results in similar output to the core and byos_hanami servers.

This does result in some inefficiency, mind, in that namespaced responses will get parsed twice.

**BREAKING CHANGE**: Originally, all XML was returned under the `rss` root key. This logic has been changed to use the name of the root element, which means `rss` responses will remain the same, but other XML responses will have a change in the name of the root key. The tests demonstrate the effects pretty clearly. The namespacing logic will work without this change, but it seemed a sensible change to make the output more predictable and better align with core nonetheless.

This resolves #186.