### PR TITLE
fix: fix 500 crash on /playlists view after deleting plugins

### DIFF
--- a/resources/views/livewire/playlists/index.blade.php
+++ b/resources/views/livewire/playlists/index.blade.php
@@ -213,12 +213,12 @@ new class extends Component
                                                                     <div class="font-medium">{{ $item->getMashupName() }}</div>
                                                                     <div class="text-xs text-zinc-500 dark:text-zinc-400">
                                                                         <flux:icon name="mashup-{{ $item->getMashupLayoutType() }}" class="inline-block pb-1" variant="mini" />
-                                                                        {{ collect($item->getMashupPluginIds())->map(fn($id) => App\Models\Plugin::find($id)->name)->join(' | ') }}
+                                                                        {{ collect($item->getMashupPluginIds())->map(fn($id) => App\Models\Plugin::find($id)?->name ?? '(deleted)')->join(' | ') }}
                                                                     </div>
                                                                 </div>
                                                             </div>
                                                         @else
-                                                            <div class="font-medium">{{ $item->plugin->name }}</div>
+                                                            <div class="font-medium">{{ $item->plugin?->name ?? '(deleted plugin)' }}</div>
                                                         @endif
                                                     </td>
                                                     <td class="py-3 px-3 first:pl-0 last:pr-0 text-sm whitespace-nowrap text-zinc-500 dark:text-zinc-300">
@@ -247,7 +247,7 @@ new class extends Component
                                                                     @if($item->isMashup())
                                                                         Delete {{ $item->getMashupName() }}?
                                                                     @else
-                                                                        Delete {{ $item->plugin->name }}?
+                                                                        Delete {{ $item->plugin?->name ?? 'plugin' }}?
                                                                     @endif
                                                                 </flux:heading>
                                                                 <p class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">


### PR DESCRIPTION
I deleted a plugin that was still used in a playlist. Now opening /playlists gave me a 500. The fix was to to allow for null plugin before accessing it's name. Logs provided in #210 

Since it's a simple fix I didn't add any tests. unit tests still complete (except for one which OOMs my devcontainer, but I assume it's completely unrelated).