### PR TITLE
Fix: Set default sleep mode start/end time to avoid null value

### DIFF
--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -9,6 +9,10 @@ use Livewire\Component;
 
 new class extends Component
 {
+    private const DEFAULT_SLEEP_MODE_FROM = '22:00';
+
+    private const DEFAULT_SLEEP_MODE_TO = '06:00';
+
     public $device;
 
     public $name;
@@ -105,9 +109,30 @@ new class extends Component
         $this->is_mirror = $device->mirror_device_id !== null;
         $this->mirror_device_id = $device->mirror_device_id;
 
+        $this->applyDefaultSleepModeTimes();
+
         return view('livewire.devices.configure', [
             'image' => ($current_image_uuid) ? url($current_image_path) : null,
         ]);
+    }
+
+    public function updatedSleepModeEnabled(bool $enabled): void
+    {
+        if (! $enabled) {
+            return;
+        }
+
+        $this->applyDefaultSleepModeTimes();
+    }
+
+    private function applyDefaultSleepModeTimes(): void
+    {
+        if (! $this->sleep_mode_enabled) {
+            return;
+        }
+
+        $this->sleep_mode_from ??= self::DEFAULT_SLEEP_MODE_FROM;
+        $this->sleep_mode_to ??= self::DEFAULT_SLEEP_MODE_TO;
     }
 
     public function deleteDevice(App\Models\Device $device)
@@ -154,9 +179,12 @@ new class extends Component
             'mirror_device_id' => 'required_if:is_mirror,true',
             'maximum_compatibility' => 'boolean',
             'sleep_mode_enabled' => 'boolean',
-            'sleep_mode_from' => 'nullable|date_format:H:i',
-            'sleep_mode_to' => 'nullable|date_format:H:i',
+            'sleep_mode_from' => 'nullable|required_if:sleep_mode_enabled,true|date_format:H:i',
+            'sleep_mode_to' => 'nullable|required_if:sleep_mode_enabled,true|date_format:H:i',
             'special_function' => 'nullable|string',
+        ], [
+            'sleep_mode_from.required_if' => 'A sleep mode start time is required when sleep mode is enabled.',
+            'sleep_mode_to.required_if' => 'A sleep mode end time is required when sleep mode is enabled.',
         ]);
 
         if ($this->is_mirror) {
@@ -493,8 +521,8 @@ new class extends Component
                         </div>
                         @if($sleep_mode_enabled)
                             <div class="flex gap-4 mb-4">
-                                <flux:input type="time" label="From" wire:model="sleep_mode_from"/>
-                                <flux:input type="time" label="To" wire:model="sleep_mode_to" />
+                                <flux:input type="time" label="From" wire:model.fill="sleep_mode_from"/>
+                                <flux:input type="time" label="To" wire:model.fill="sleep_mode_to" />
                             </div>
                         @endif
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -438,8 +438,8 @@ Route::post('/display/status', function (Request $request) {
         'name' => 'string|max:255',
         'default_refresh_interval' => 'integer|min:1',
         'sleep_mode_enabled' => 'boolean',
-        'sleep_mode_from' => 'nullable|date_format:H:i',
-        'sleep_mode_to' => 'nullable|date_format:H:i',
+        'sleep_mode_from' => 'nullable|required_if:sleep_mode_enabled,true|date_format:H:i',
+        'sleep_mode_to' => 'nullable|required_if:sleep_mode_enabled,true|date_format:H:i',
         'pause_until' => 'nullable|date|after:now',
     ]);
 

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -907,6 +907,25 @@ test('device not in sleep mode returns normal image', function (): void {
     Carbon\Carbon::setTestNow(); // Clear test time
 });
 
+test('display status update requires sleep mode times when sleep mode is enabled', function (): void {
+    $user = User::factory()->create();
+    $device = Device::factory()->create([
+        'user_id' => $user->id,
+        'sleep_mode_enabled' => false,
+    ]);
+
+    Sanctum::actingAs($user);
+
+    $response = $this->postJson('/api/display/status', [
+        'device_id' => $device->id,
+        'sleep_mode_enabled' => true,
+        'sleep_mode_to' => '06:00',
+    ]);
+
+    $response->assertStatus(422)
+        ->assertJsonValidationErrors(['sleep_mode_from']);
+});
+
 test('device returns sleep.png and correct refresh time when paused', function (): void {
     $device = Device::factory()->create([
         'mac_address' => '00:11:22:33:44:55',

--- a/tests/Feature/Devices/DeviceConfigureTest.php
+++ b/tests/Feature/Devices/DeviceConfigureTest.php
@@ -56,3 +56,47 @@ test('configure edit modal shows mirror checkbox and allows unchecking mirror', 
     $mirrorDevice->refresh();
     expect($mirrorDevice->mirror_device_id)->toBeNull();
 });
+
+test('configure update requires sleep mode times when sleep mode is enabled', function (): void {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $device = Device::factory()->create([
+        'user_id' => $user->id,
+        'width' => 800,
+        'height' => 480,
+        'rotate' => 0,
+        'image_format' => 'png',
+        'sleep_mode_enabled' => true,
+        'sleep_mode_from' => '22:00',
+        'sleep_mode_to' => '06:00',
+    ]);
+
+    Livewire::test('devices.configure', ['device' => $device])
+        ->set('sleep_mode_enabled', true)
+        ->set('sleep_mode_from', null)
+        ->set('sleep_mode_to', '06:00')
+        ->call('updateDevice')
+        ->assertHasErrors(['sleep_mode_from' => ['required_if']]);
+});
+
+test('enabling sleep mode applies default times when none are set', function (): void {
+    $user = User::factory()->create();
+    actingAs($user);
+
+    $device = Device::factory()->create([
+        'user_id' => $user->id,
+        'width' => 800,
+        'height' => 480,
+        'rotate' => 0,
+        'image_format' => 'png',
+        'sleep_mode_enabled' => false,
+        'sleep_mode_from' => null,
+        'sleep_mode_to' => null,
+    ]);
+
+    Livewire::test('devices.configure', ['device' => $device])
+        ->set('sleep_mode_enabled', true)
+        ->assertSet('sleep_mode_from', '22:00')
+        ->assertSet('sleep_mode_to', '06:00');
+});


### PR DESCRIPTION
In some circumstances, setting a sleep mode start/end time will send null values.

This tends to happen in cases where the full HH:MM timestamp is not entered into these fields. Submitting the form will result in either `sleep_mode_from`, `sleep_mode_to` or both being sent to Larapaper as null.

```
          "sleep_mode_enabled": true,
          "sleep_mode_from": null,
          "sleep_mode_to": "03:00",
``` 

This case will break sleep mode, causing Larapaper to use the default `refresh_rate` instead.