### PR TITLE
feat(#242): added "merge_strategy" for webhooks

### DIFF
--- a/app/Http/Controllers/Api/PluginWebhookController.php
+++ b/app/Http/Controllers/Api/PluginWebhookController.php
@@ -6,6 +6,8 @@ use App\Http\Controllers\Controller;
 use App\Models\Plugin;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 
 class PluginWebhookController extends Controller
 {
@@ -15,11 +17,39 @@ class PluginWebhookController extends Controller
             return response()->json(['error' => 'Plugin does not use webhook strategy'], 400);
         }
 
+        if ($request->isMethod('get')) {
+            return response()->json([
+                'merge_variables' => $plugin->data_payload ?? [],
+            ]);
+        }
+
         if (! $request->has('merge_variables')) {
             return response()->json(['error' => 'Request must contain merge_variables key'], 400);
         }
 
-        $mergeVariables = $request->input('merge_variables');
+        $validator = Validator::make(
+            $request->all(),
+            [
+                'merge_strategy' => ['nullable', 'string', Rule::in(Plugin::webhookMergeStrategies())],
+                'stream_limit' => ['nullable', 'integer', 'min:1'],
+            ],
+            [
+                'merge_strategy.in' => 'merge_strategy must be one of: deep_merge, stream',
+                'stream_limit.integer' => 'stream_limit must be a positive integer',
+                'stream_limit.min' => 'stream_limit must be a positive integer',
+            ]
+        );
+
+        if ($validator->fails()) {
+            return response()->json(['error' => $validator->errors()->first()], 400);
+        }
+
+        $mergeVariables = Plugin::mergeWebhookPayload(
+            currentPayload: $plugin->data_payload,
+            incomingPayload: $request->input('merge_variables'),
+            mergeStrategy: $request->string('merge_strategy')->toString() ?: null,
+            streamLimit: $request->has('stream_limit') ? (int) $request->input('stream_limit') : null,
+        );
 
         if (! Plugin::dataPayloadWithinWireLimit($mergeVariables)) {
             return response()->json(Plugin::oversizedDataPayloadErrorPayload(), 413);

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -258,6 +258,10 @@ class Plugin extends Model
     /** Extra reserve for the recipe form body (markup, views, other properties). */
     private const RECIPE_STATIC_FIELD_RESERVE_BYTES = 1024 * 1024;
 
+    public const WEBHOOK_MERGE_STRATEGY_DEEP_MERGE = 'deep_merge';
+
+    public const WEBHOOK_MERGE_STRATEGY_STREAM = 'stream';
+
     /** Max pretty-encoded data_payload size for Livewire; null when unlimited. */
     public static function maxDataPayloadBytesForWire(): ?int
     {
@@ -319,6 +323,89 @@ class Plugin extends Model
     public static function oversizedDataPayloadErrorPayload(): array
     {
         return ['error' => 'Data payload exceeds maximum allowed size'];
+    }
+
+    /** Supported TRMNL webhook merge strategies for recipe plugins. */
+    public static function webhookMergeStrategies(): array
+    {
+        return [
+            self::WEBHOOK_MERGE_STRATEGY_DEEP_MERGE,
+            self::WEBHOOK_MERGE_STRATEGY_STREAM,
+        ];
+    }
+
+    public static function mergeWebhookPayload(
+        mixed $currentPayload,
+        mixed $incomingPayload,
+        ?string $mergeStrategy = null,
+        ?int $streamLimit = null,
+    ): mixed {
+        return match ($mergeStrategy) {
+            null, '' => $incomingPayload,
+            self::WEBHOOK_MERGE_STRATEGY_DEEP_MERGE => self::deepMergeWebhookPayload($currentPayload, $incomingPayload),
+            self::WEBHOOK_MERGE_STRATEGY_STREAM => self::streamWebhookPayload($currentPayload, $incomingPayload, $streamLimit),
+            default => throw new InvalidArgumentException("Unsupported webhook merge strategy [{$mergeStrategy}]"),
+        };
+    }
+
+    private static function deepMergeWebhookPayload(mixed $currentPayload, mixed $incomingPayload): mixed
+    {
+        if (! is_array($currentPayload) || ! is_array($incomingPayload)) {
+            return $incomingPayload;
+        }
+
+        $mergedPayload = $currentPayload;
+
+        foreach ($incomingPayload as $key => $value) {
+            if (
+                array_key_exists($key, $mergedPayload)
+                && self::isAssociativeArray($mergedPayload[$key])
+                && self::isAssociativeArray($value)
+            ) {
+                $mergedPayload[$key] = self::deepMergeWebhookPayload($mergedPayload[$key], $value);
+
+                continue;
+            }
+
+            $mergedPayload[$key] = $value;
+        }
+
+        return $mergedPayload;
+    }
+
+    private static function streamWebhookPayload(mixed $currentPayload, mixed $incomingPayload, ?int $streamLimit): mixed
+    {
+        if (! is_array($incomingPayload)) {
+            return $incomingPayload;
+        }
+
+        $mergedPayload = is_array($currentPayload) ? $currentPayload : [];
+
+        foreach ($incomingPayload as $key => $value) {
+            if (is_array($value) && array_is_list($value)) {
+                $existingValue = $mergedPayload[$key] ?? [];
+                $streamedValue = is_array($existingValue) && array_is_list($existingValue)
+                    ? [...$existingValue, ...$value]
+                    : $value;
+
+                if ($streamLimit !== null) {
+                    $streamedValue = array_slice($streamedValue, -$streamLimit);
+                }
+
+                $mergedPayload[$key] = $streamedValue;
+
+                continue;
+            }
+
+            $mergedPayload[$key] = $value;
+        }
+
+        return $mergedPayload;
+    }
+
+    private static function isAssociativeArray(mixed $value): bool
+    {
+        return is_array($value) && ! array_is_list($value);
     }
 
     public function updateDataPayload(): void

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1140,15 +1140,16 @@ HTML;
                         </div>
                     @elseif($data_strategy === 'webhook')
                         <div class="mb-4">
-                            <flux:input
-                                label="Webhook URL"
-                                descriptionTrailing="Send JSON payload with key <code>merge_variables</code> to the webhook URL. The payload will be merged with the plugin data."
-                                :value="route('api.custom_plugins.webhook', ['plugin' => $plugin->uuid])"
-                                class="block mt-1 w-full font-mono"
-                                readonly
-                                copyable
-                            >
-                            </flux:input>
+                            <flux:field>
+                                <flux:label>Webhook URL</flux:label>
+                                <flux:input
+                                    :value="route('api.custom_plugins.webhook', ['plugin' => $plugin->uuid])"
+                                    class="block mt-1 w-full font-mono"
+                                    readonly
+                                    copyable
+                                />
+                                <flux:description>POST JSON with <code>merge_variables</code> to replace data, or add <code>merge_strategy</code> of <code>deep_merge</code> or <code>stream</code>. GET the same URL to retrieve the latest stored <code>merge_variables</code>.</flux:description>
+                            </flux:field>
                         </div>
                     @elseif($data_strategy === 'static')
                         <flux:text class="mb-2">Enter static JSON data in the Data Payload field.</flux:text>

--- a/routes/api.php
+++ b/routes/api.php
@@ -53,7 +53,7 @@ Route::middleware('auth:sanctum')->group(function () {
 | Public plugin endpoints (uuid-scoped route-model binding)
 |--------------------------------------------------------------------------
 */
-Route::post('/custom_plugins/{plugin:uuid}', PluginWebhookController::class)
+Route::match(['get', 'post'], '/custom_plugins/{plugin:uuid}', PluginWebhookController::class)
     ->name('api.custom_plugins.webhook');
 
 Route::post('/plugins/{plugin:uuid}/webhook', PluginActionController::class)

--- a/tests/Feature/PluginWebhookTest.php
+++ b/tests/Feature/PluginWebhookTest.php
@@ -26,6 +26,26 @@ test('webhook updates plugin data for webhook strategy', function (): void {
     ]);
 });
 
+test('webhook returns stored merge variables for webhook strategy', function (): void {
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'webhook',
+        'data_payload' => [
+            'text' => 'Latest payload',
+            'metrics' => ['temperature' => 42],
+        ],
+    ]);
+
+    $response = $this->getJson("/api/custom_plugins/{$plugin->uuid}");
+
+    $response->assertOk()
+        ->assertJson([
+            'merge_variables' => [
+                'text' => 'Latest payload',
+                'metrics' => ['temperature' => 42],
+            ],
+        ]);
+});
+
 test('webhook returns 400 for non-webhook strategy plugins', function (): void {
     // Create a plugin with non-webhook strategy
     $plugin = Plugin::factory()->create([
@@ -43,6 +63,85 @@ test('webhook returns 400 for non-webhook strategy plugins', function (): void {
         ->assertJson(['error' => 'Plugin does not use webhook strategy']);
 });
 
+test('webhook deep_merge updates nested payload keys without replacing siblings', function (): void {
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'webhook',
+        'data_payload' => [
+            'sensor' => [
+                'temperature' => 40,
+                'humidity' => 55,
+            ],
+            'status' => 'ok',
+        ],
+    ]);
+
+    $response = $this->postJson("/api/custom_plugins/{$plugin->uuid}", [
+        'merge_variables' => [
+            'sensor' => ['temperature' => 42],
+        ],
+        'merge_strategy' => 'deep_merge',
+    ]);
+
+    $response->assertOk()
+        ->assertJson(['message' => 'Data updated successfully']);
+
+    expect($plugin->fresh()->data_payload)->toBe([
+        'sensor' => [
+            'temperature' => 42,
+            'humidity' => 55,
+        ],
+        'status' => 'ok',
+    ]);
+});
+
+test('webhook stream appends top level arrays and preserves other keys', function (): void {
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'webhook',
+        'data_payload' => [
+            'temperatures' => [38, 39],
+            'status' => 'ok',
+        ],
+    ]);
+
+    $response = $this->postJson("/api/custom_plugins/{$plugin->uuid}", [
+        'merge_variables' => [
+            'temperatures' => [40, 42],
+            'status' => 'alert',
+        ],
+        'merge_strategy' => 'stream',
+    ]);
+
+    $response->assertOk();
+
+    expect($plugin->fresh()->data_payload)->toBe([
+        'temperatures' => [38, 39, 40, 42],
+        'status' => 'alert',
+    ]);
+});
+
+test('webhook stream_limit trims older streamed items', function (): void {
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'webhook',
+        'data_payload' => [
+            'temperatures' => [36, 37, 38],
+        ],
+    ]);
+
+    $response = $this->postJson("/api/custom_plugins/{$plugin->uuid}", [
+        'merge_variables' => [
+            'temperatures' => [39, 40],
+        ],
+        'merge_strategy' => 'stream',
+        'stream_limit' => 4,
+    ]);
+
+    $response->assertOk();
+
+    expect($plugin->fresh()->data_payload)->toBe([
+        'temperatures' => [37, 38, 39, 40],
+    ]);
+});
+
 test('webhook returns 400 when merge_variables is missing', function (): void {
     // Create a plugin with webhook strategy
     $plugin = Plugin::factory()->create([
@@ -56,6 +155,35 @@ test('webhook returns 400 when merge_variables is missing', function (): void {
     // Assert response
     $response->assertStatus(400)
         ->assertJson(['error' => 'Request must contain merge_variables key']);
+});
+
+test('webhook returns 400 for invalid merge_strategy', function (): void {
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'webhook',
+    ]);
+
+    $response = $this->postJson("/api/custom_plugins/{$plugin->uuid}", [
+        'merge_variables' => ['new' => 'data'],
+        'merge_strategy' => 'append_forever',
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJson(['error' => 'merge_strategy must be one of: deep_merge, stream']);
+});
+
+test('webhook returns 400 for invalid stream_limit', function (): void {
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'webhook',
+    ]);
+
+    $response = $this->postJson("/api/custom_plugins/{$plugin->uuid}", [
+        'merge_variables' => ['temperatures' => [42]],
+        'merge_strategy' => 'stream',
+        'stream_limit' => 0,
+    ]);
+
+    $response->assertStatus(400)
+        ->assertJson(['error' => 'stream_limit must be a positive integer']);
 });
 
 test('webhook returns 404 for non-existent plugin', function (): void {
@@ -87,4 +215,27 @@ test('webhook rejects merge_variables that exceed the wire size limit', function
         ->assertJson(Plugin::oversizedDataPayloadErrorPayload());
 
     expect($plugin->fresh()->data_payload)->toBe(['old' => 'data']);
+});
+
+test('webhook rejects merged payloads that exceed the wire size limit', function (): void {
+    config(['livewire.payload.max_size' => 768]);
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'webhook',
+        'data_payload' => ['temperatures' => [str_repeat('A', 240)]],
+    ]);
+
+    $response = $this->postJson("/api/custom_plugins/{$plugin->uuid}", [
+        'merge_variables' => [
+            'temperatures' => [str_repeat('B', 240)],
+        ],
+        'merge_strategy' => 'stream',
+    ]);
+
+    $response->assertStatus(413)
+        ->assertJson(Plugin::oversizedDataPayloadErrorPayload());
+
+    expect($plugin->fresh()->data_payload)->toBe([
+        'temperatures' => [str_repeat('A', 240)],
+    ]);
 });


### PR DESCRIPTION
Added "merge_strategy" for webhooks, accepting "deep_merge" and "streams" as inputs. Also added GET route for webhooks to get the current value.

Fixed issue with <code> formatting in recipe.blade.php.