### PR TITLE
Add TRMNL_SKIP_DISPLAY support to playlist rotation

### DIFF
--- a/app/Actions/Api/RunDeviceDisplayCycle.php
+++ b/app/Actions/Api/RunDeviceDisplayCycle.php
@@ -4,6 +4,7 @@ namespace App\Actions\Api;
 
 use App\Jobs\GenerateScreenJob;
 use App\Models\Device;
+use App\Models\PlaylistItem;
 use App\Models\Plugin;
 use App\Plugins\Enums\PluginOutput;
 use App\Services\DeviceImageResolver;
@@ -72,34 +73,68 @@ class RunDeviceDisplayCycle
             return null;
         }
 
-        $refreshTimeOverride = $playlistItem->playlist()->first()->refresh_time;
+        $playlist = $playlistItem->playlist;
+        $refreshTimeOverride = $playlist?->refresh_time;
 
-        if (! $playlistItem->isMashup()) {
-            $this->renderSinglePlugin($device, $playlistItem);
-        } else {
-            $this->renderMashup($device, $playlistItem);
+        if (! $playlist) {
+            return null;
+        }
+
+        foreach ($playlist->getCycleItemsStartingFrom($playlistItem) as $candidate) {
+            if ($candidate->isMashup()) {
+                $this->renderMashup($device, $candidate);
+
+                return $refreshTimeOverride;
+            }
+
+            if ($this->renderSinglePlugin($device, $candidate)) {
+                return $refreshTimeOverride;
+            }
         }
 
         return $refreshTimeOverride;
     }
 
-    private function renderSinglePlugin(Device $device, $playlistItem): void
+    private function renderSinglePlugin(Device $device, PlaylistItem $playlistItem): bool
     {
         $plugin = $playlistItem->plugin;
 
         ImageGenerationService::resetIfNotCacheable($plugin, $device);
         $plugin->refresh();
 
-        if ($plugin->isDataStale() || $plugin->current_image === null) {
+        $isDataStale = $plugin->isDataStale();
+
+        if (! $isDataStale && $this->shouldSkipFromPayload($plugin)) {
+            return false;
+        }
+
+        if ($isDataStale) {
             $plugin->updateDataPayload();
+            $plugin->refresh();
+        }
+
+        if ($this->shouldSkipFromPayload($plugin)) {
+            return false;
+        }
+
+        $needsRender = $isDataStale || $plugin->current_image === null;
+
+        if ($needsRender) {
             try {
                 $usesMarkupPipeline = $plugin->handler()?->output() !== PluginOutput::Image;
                 $markup = $usesMarkupPipeline ? $plugin->render(device: $device) : '';
+
+                if ($usesMarkupPipeline && $this->shouldSkipFromMarkup($markup)) {
+                    return false;
+                }
+
                 GenerateScreenJob::dispatchSync($device->id, $plugin->id, $markup);
             } catch (Exception $e) {
                 Log::error("Failed to render plugin {$plugin->id} ({$plugin->name}): ".$e->getMessage());
                 $errorImageUuid = ImageGenerationService::generateDefaultScreenImage($device, 'error', $plugin->name);
                 $device->update(['current_screen_image' => $errorImageUuid]);
+
+                return true;
             }
         }
 
@@ -108,7 +143,11 @@ class RunDeviceDisplayCycle
         if ($plugin->current_image !== null) {
             $playlistItem->update(['last_displayed_at' => now()]);
             $device->update(['current_screen_image' => $plugin->current_image]);
+
+            return true;
         }
+
+        return true;
     }
 
     private function renderMashup(Device $device, $playlistItem): void
@@ -137,6 +176,20 @@ class RunDeviceDisplayCycle
         if ($device->current_screen_image !== null) {
             $playlistItem->update(['last_displayed_at' => now()]);
         }
+    }
+
+    private function shouldSkipFromPayload(Plugin $plugin): bool
+    {
+        return is_array($plugin->data_payload)
+            && ($plugin->data_payload['TRMNL_SKIP_DISPLAY'] ?? false) === true;
+    }
+
+    private function shouldSkipFromMarkup(string $markup): bool
+    {
+        return preg_match(
+            '/<script\b[^>]*>.*?window\.TRMNL_SKIP_DISPLAY\s*=\s*true\b.*?<\/script>/is',
+            $markup
+        ) === 1;
     }
 
     /**

--- a/app/Models/Playlist.php
+++ b/app/Models/Playlist.php
@@ -6,6 +6,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Collection;
 
 class Playlist extends Model
 {
@@ -93,12 +94,8 @@ class Playlist extends Model
             return null;
         }
 
-        // Get active playlist items ordered by display order
-        /** @var \Illuminate\Support\Collection|PlaylistItem[] $playlistItems */
-        $playlistItems = $this->items()
-            ->where('is_active', true)
-            ->orderBy('order')
-            ->get();
+        /** @var Collection<int, PlaylistItem> $playlistItems */
+        $playlistItems = $this->getActiveItems();
 
         if ($playlistItems->isEmpty()) {
             return null;
@@ -126,5 +123,47 @@ class Playlist extends Model
         }
 
         return $nextItem;
+    }
+
+    /**
+     * @return Collection<int, PlaylistItem>
+     */
+    public function getActiveItems(): Collection
+    {
+        return $this->items()
+            ->where('is_active', true)
+            ->orderBy('order')
+            ->get();
+    }
+
+    /**
+     * @return Collection<int, PlaylistItem>
+     */
+    public function getCycleItemsStartingFrom(?PlaylistItem $startingItem = null): Collection
+    {
+        $playlistItems = $this->getActiveItems();
+
+        if ($playlistItems->isEmpty()) {
+            return collect();
+        }
+
+        $startingItem ??= $this->getNextPlaylistItem();
+
+        if (! $startingItem) {
+            return collect();
+        }
+
+        $startingIndex = $playlistItems->search(
+            fn (PlaylistItem $playlistItem): bool => $playlistItem->id === $startingItem->id
+        );
+
+        if ($startingIndex === false) {
+            return $playlistItems->values();
+        }
+
+        return $playlistItems
+            ->slice($startingIndex)
+            ->concat($playlistItems->take($startingIndex))
+            ->values();
     }
 }

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -9,6 +9,7 @@ use App\Models\Plugin;
 use App\Models\User;
 use App\Services\ImageGenerationService;
 use Bnussbau\EpaperPipeline\EpaperPipeline;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\Facades\Storage;
 use Laravel\Sanctum\Sanctum;
@@ -719,6 +720,370 @@ test('plugins in playlist are rendered in order', function (): void {
     $thirdResponse->assertOk();
     expect($thirdResponse['filename'])
         ->not->toBe($secondResponse['filename']);
+});
+
+test('display endpoint keeps current screen when all active playlist items are skipped', function (): void {
+    $device = Device::factory()->create([
+        'mac_address' => '55:11:22:33:44:77',
+        'api_key' => 'all-skip-api-key',
+        'proxy_cloud' => false,
+        'current_screen_image' => 'stable-screen',
+    ]);
+
+    $imageMetadata = ImageGenerationService::buildImageMetadataFromDevice($device);
+
+    $firstSkipPlugin = Plugin::factory()->create([
+        'name' => 'First Skip Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => null,
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload' => ['TRMNL_SKIP_DISPLAY' => true],
+        'data_payload_updated_at' => now(),
+        'current_image' => 'first-skip-image',
+        'current_image_metadata' => $imageMetadata,
+    ]);
+
+    $secondSkipPlugin = Plugin::factory()->create([
+        'name' => 'Second Skip Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => null,
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload' => ['TRMNL_SKIP_DISPLAY' => true],
+        'data_payload_updated_at' => now(),
+        'current_image' => 'second-skip-image',
+        'current_image_metadata' => $imageMetadata,
+    ]);
+
+    Storage::disk('public')->put('images/generated/stable-screen.bmp', 'stable');
+
+    $playlist = Playlist::factory()->create([
+        'device_id' => $device->id,
+        'name' => 'All Skip Test',
+        'is_active' => true,
+        'weekdays' => null,
+        'active_from' => null,
+        'active_until' => null,
+    ]);
+
+    $firstSkippedItem = PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $firstSkipPlugin->id,
+        'order' => 1,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    $secondSkippedItem = PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $secondSkipPlugin->id,
+        'order' => 2,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    $response = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $response->assertOk();
+
+    expect($response['filename'])->toBe('stable-screen.bmp')
+        ->and($firstSkippedItem->fresh()->last_displayed_at)->toBeNull()
+        ->and($secondSkippedItem->fresh()->last_displayed_at)->toBeNull();
+});
+
+test('display endpoint skips playlist items when rendered markup requests TRMNL skip', function (): void {
+    $device = Device::factory()->create([
+        'mac_address' => '55:11:22:33:44:99',
+        'api_key' => 'markup-skip-api-key',
+        'proxy_cloud' => false,
+    ]);
+
+    $imageMetadata = ImageGenerationService::buildImageMetadataFromDevice($device);
+
+    $skipPlugin = Plugin::factory()->create([
+        'name' => 'Markup Skip Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => null,
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload' => ['headline' => 'Skip me'],
+        'data_payload_updated_at' => now(),
+        'current_image' => null,
+        'markup_language' => 'blade',
+        'render_markup' => <<<'BLADE'
+<div>Hidden</div>
+<script>
+window.TRMNL_SKIP_DISPLAY = true;
+</script>
+BLADE,
+    ]);
+
+    $nextPlugin = Plugin::factory()->create([
+        'name' => 'Next Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => null,
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload' => ['headline' => 'Visible item'],
+        'data_payload_updated_at' => now(),
+        'current_image' => 'next-markup-plugin-image',
+        'current_image_metadata' => $imageMetadata,
+    ]);
+
+    Storage::disk('public')->put('images/generated/next-markup-plugin-image.bmp', 'next');
+
+    $playlist = Playlist::factory()->create([
+        'device_id' => $device->id,
+        'name' => 'Markup Skip Test',
+        'is_active' => true,
+        'weekdays' => null,
+        'active_from' => null,
+        'active_until' => null,
+    ]);
+
+    $skippedItem = PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $skipPlugin->id,
+        'order' => 1,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $nextPlugin->id,
+        'order' => 2,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    $response = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $response->assertOk();
+
+    expect($response['filename'])->toBe('next-markup-plugin-image.bmp')
+        ->and($skippedItem->fresh()->last_displayed_at)->toBeNull();
+});
+
+test('display endpoint continues normal playlist rotation after skipping an item', function (): void {
+    Http::fake([
+        'https://example.com/rotation-skip' => Http::response([
+            'TRMNL_SKIP_DISPLAY' => true,
+        ], 200),
+    ]);
+
+    $device = Device::factory()->create([
+        'mac_address' => '55:11:22:33:44:88',
+        'api_key' => 'skip-rotation-api-key',
+        'proxy_cloud' => false,
+    ]);
+
+    $imageMetadata = ImageGenerationService::buildImageMetadataFromDevice($device);
+
+    $skipPlugin = Plugin::factory()->create([
+        'name' => 'Rotation Skip Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => 'https://example.com/rotation-skip',
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'render_markup_view' => 'trmnl',
+        'data_payload_updated_at' => null,
+        'current_image' => null,
+    ]);
+
+    $secondPlugin = Plugin::factory()->create([
+        'name' => 'Second Visible Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => null,
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload' => ['headline' => 'Visible item B'],
+        'data_payload_updated_at' => now(),
+        'current_image' => 'rotation-visible-b',
+        'current_image_metadata' => $imageMetadata,
+    ]);
+
+    $thirdPlugin = Plugin::factory()->create([
+        'name' => 'Third Visible Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => null,
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload' => ['headline' => 'Visible item C'],
+        'data_payload_updated_at' => now(),
+        'current_image' => 'rotation-visible-c',
+        'current_image_metadata' => $imageMetadata,
+    ]);
+
+    Storage::disk('public')->put('images/generated/rotation-visible-b.bmp', 'visible-b');
+    Storage::disk('public')->put('images/generated/rotation-visible-c.bmp', 'visible-c');
+
+    $playlist = Playlist::factory()->create([
+        'device_id' => $device->id,
+        'name' => 'Skip Rotation Test',
+        'is_active' => true,
+        'weekdays' => null,
+        'active_from' => null,
+        'active_until' => null,
+    ]);
+
+    $skippedItem = PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $skipPlugin->id,
+        'order' => 1,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    $secondVisibleItem = PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $secondPlugin->id,
+        'order' => 2,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    $thirdVisibleItem = PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $thirdPlugin->id,
+        'order' => 3,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    $firstResponse = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $firstResponse->assertOk();
+    expect($firstResponse['filename'])->toBe('rotation-visible-b.bmp')
+        ->and($skippedItem->fresh()->last_displayed_at)->toBeNull()
+        ->and($secondVisibleItem->fresh()->last_displayed_at)->not->toBeNull()
+        ->and($thirdVisibleItem->fresh()->last_displayed_at)->toBeNull();
+
+    $this->travel(1)->seconds();
+
+    $secondResponse = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $secondResponse->assertOk();
+    expect($secondResponse['filename'])->toBe('rotation-visible-c.bmp')
+        ->and($skippedItem->fresh()->last_displayed_at)->toBeNull()
+        ->and($secondVisibleItem->fresh()->last_displayed_at)->not->toBeNull()
+        ->and($thirdVisibleItem->fresh()->last_displayed_at)->not->toBeNull();
+});
+
+test('display endpoint does not re-poll fresh skip payloads on later rotation passes', function (): void {
+    Http::fake([
+        'https://example.com/fresh-skip' => Http::response([
+            'TRMNL_SKIP_DISPLAY' => true,
+        ], 200),
+    ]);
+
+    $device = Device::factory()->create([
+        'mac_address' => '55:11:22:33:44:89',
+        'api_key' => 'fresh-skip-api-key',
+        'proxy_cloud' => false,
+    ]);
+
+    $imageMetadata = ImageGenerationService::buildImageMetadataFromDevice($device);
+
+    $skipPlugin = Plugin::factory()->create([
+        'name' => 'Fresh Skip Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => 'https://example.com/fresh-skip',
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload_updated_at' => null,
+        'current_image' => null,
+    ]);
+
+    $visiblePlugin = Plugin::factory()->create([
+        'name' => 'Visible After Skip Plugin',
+        'data_strategy' => 'polling',
+        'polling_url' => null,
+        'polling_verb' => 'get',
+        'data_stale_minutes' => 5,
+        'data_payload' => ['headline' => 'Visible item'],
+        'data_payload_updated_at' => now(),
+        'current_image' => 'visible-after-skip-image',
+        'current_image_metadata' => $imageMetadata,
+    ]);
+
+    Storage::disk('public')->put('images/generated/visible-after-skip-image.bmp', 'visible-after-skip');
+
+    $playlist = Playlist::factory()->create([
+        'device_id' => $device->id,
+        'name' => 'Fresh Skip Polling Test',
+        'is_active' => true,
+        'weekdays' => null,
+        'active_from' => null,
+        'active_until' => null,
+    ]);
+
+    PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $skipPlugin->id,
+        'order' => 1,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    PlaylistItem::factory()->create([
+        'playlist_id' => $playlist->id,
+        'plugin_id' => $visiblePlugin->id,
+        'order' => 2,
+        'is_active' => true,
+        'last_displayed_at' => null,
+    ]);
+
+    $firstResponse = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $firstResponse->assertOk();
+    expect($firstResponse['filename'])->toBe('visible-after-skip-image.bmp');
+
+    $this->travel(1)->seconds();
+
+    $secondResponse = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $secondResponse->assertOk();
+    expect($secondResponse['filename'])->toBe('visible-after-skip-image.bmp');
+
+    Http::assertSentCount(1);
 });
 
 test('display endpoint updates last_refreshed_at timestamp', function (): void {


### PR DESCRIPTION
Closes #245

This adds server-side support for `TRMNL_SKIP_DISPLAY` in LaraPaper playlist rotation.

Supported cases:
- top level `TRMNL_SKIP_DISPLAY: true` in polling payloads
- `window.TRMNL_SKIP_DISPLAY = true` in plugin markup

Behavior:
- if a playlist item returns one of these skip signals, LaraPaper skips it server-side
- the rotation continues with the next eligible item in the same active playlist
- if all active items in the playlist are skipped, the existing fallback behavior is preserved

Notes:
- supports single-plugin playlist items only
- mashup-specific skip behavior is intentionally left out as core also does not support that based on the docs
- tests added for skip rotation and fresh payload polling
- manually verified both markup-based and payload-based skip behavior in a local LaraPaper Docker setup