### PR TITLE
fix: polling timeout was greater than device timeout

### DIFF
--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -21,6 +21,7 @@ use Closure;
 use Exception;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Client\Pool;
 use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Blade;
@@ -464,36 +465,44 @@ class Plugin extends Model
             filled(...)
         ));
 
-        $combinedResponse = [];
+        $resolvedBody = ($this->polling_verb === 'post' && $this->polling_body)
+            ? $this->resolveLiquidVariables($this->polling_body)
+            : null;
+        $contentType = $headers['Content-Type'] ?? 'application/json';
 
-        // Loop through all URLs (Handles 1 or many)
-        foreach ($urls as $index => $url) {
-            $httpRequest = Http::withHeaders($headers);
-
-            if ($this->polling_verb === 'post' && $this->polling_body) {
-                $contentType = (array_key_exists('Content-Type', $headers))
-                    ? $headers['Content-Type']
-                    : 'application/json';
-
-                $resolvedBody = $this->resolveLiquidVariables($this->polling_body);
-                $httpRequest = $httpRequest->withBody($resolvedBody, $contentType);
+        $isPost = $this->polling_verb === 'post';
+        $responses = Http::pool(function (Pool $pool) use ($urls, $headers, $resolvedBody, $contentType, $isPost) {
+            $requests = [];
+            foreach ($urls as $url) {
+                $request = $pool->withHeaders($headers)->timeout(10);
+                if ($isPost && $resolvedBody !== null) {
+                    $request = $request->withBody($resolvedBody, $contentType);
+                }
+                $requests[] = $isPost ? $request->post($url) : $request->get($url);
             }
 
+            return $requests;
+        });
+
+        $combinedResponse = [];
+        foreach ($urls as $index => $url) {
             try {
-                $httpResponse = ($this->polling_verb === 'post')
-                    ? $httpRequest->post($url)
-                    : $httpRequest->get($url);
+                $httpResponse = $responses[$index];
+                if ($httpResponse instanceof Exception) {
+                    throw $httpResponse;
+                }
+                if ($httpResponse->failed()) {
+                    Log::warning("Plugin {$this->id} got HTTP {$httpResponse->status()} from {$url}");
+                    $combinedResponse["IDX_{$index}"] = ['error' => 'Failed to fetch data'];
+
+                    continue;
+                }
 
                 $response = $this->parseResponse($httpResponse);
-
-                // Nest if it's a sequential array
-                if (array_keys($response) === range(0, count($response) - 1)) {
-                    $combinedResponse["IDX_{$index}"] = ['data' => $response];
-                } else {
-                    $combinedResponse["IDX_{$index}"] = $response;
-                }
+                $isSequential = array_keys($response) === range(0, count($response) - 1);
+                $combinedResponse["IDX_{$index}"] = $isSequential ? ['data' => $response] : $response;
             } catch (Exception $e) {
-                Log::warning("Failed to fetch data from URL {$url}: ".$e->getMessage());
+                Log::warning("Plugin {$this->id} failed to fetch/parse {$url}: ".$e->getMessage());
                 $combinedResponse["IDX_{$index}"] = ['error' => 'Failed to fetch data'];
             }
         }


### PR DESCRIPTION
Woke up this morning to a error screen on my TRMNL. Turned out one of the polled APIs in my plugins was hitting the default timeout of 30s.

```
172.28.10.4 - - [06/Jun/2026:12:03:40 +0000] "GET /api/display HTTP/1.1" 499 0 "-" "ESP32HTTPClient" "192.168.0.132"
[2026-06-06 13:03:41] production.INFO: Device Log {"created_at":1780747682,"id":2090,"message":"Error fetching API display: 7, detail: HTTP Client failed with error: read Timeout(-11)","source_line":1573,"source_path":"src/bl.cpp","wifi_signal":-65,"wifi_status":"connected","refresh_rate":900,"sleep_duration":289,"firmware_version":"1.8.2","special_function":"none","battery_voltage":3.588,"wake_reason":"button","free_heap_size":195108,"max_alloc_size":139264,"retry":21}
[2026-06-06 13:03:41] production.INFO: Device Log {"created_at":1780747682,"id":2090,"message":"Error fetching API display: 7, detail: HTTP Client failed with error: read Timeout(-11)","source_line":1573,"source_path":"src/bl.cpp","wifi_signal":-65,"wifi_status":"connected","refresh_rate":900,"sleep_duration":289,"firmware_version":"1.8.2","special_function":"none","battery_voltage":3.588,"wake_reason":"button","free_heap_size":195108,"max_alloc_size":139264,"retry":21}
172.28.10.4 - - [06/Jun/2026:12:03:41 +0000] "POST /api/log HTTP/1.1" 200 24 "-" "ESP32HTTPClient" "192.168.0.132"
[2026-06-06 13:03:43] production.INFO: Device Log {"created_at":1780747682,"id":2089,"message":"[HTTPS] GET... failed, error: read Timeout","source_line":145,"source_path":"src/api-client/display.cpp","wifi_signal":-65,"wifi_status":"connected","refresh_rate":900,"sleep_duration":289,"firmware_version":"1.8.2","special_function":"none","battery_voltage":3.588,"wake_reason":"button","free_heap_size":192812,"max_alloc_size":139264,"retry":21}
[2026-06-06 13:03:43] production.INFO: Device Log {"created_at":1780747682,"id":2089,"message":"[HTTPS] GET... failed, error: read Timeout","source_line":145,"source_path":"src/api-client/display.cpp","wifi_signal":-65,"wifi_status":"connected","refresh_rate":900,"sleep_duration":289,"firmware_version":"1.8.2","special_function":"none","battery_voltage":3.588,"wake_reason":"button","free_heap_size":192812,"max_alloc_size":139264,"retry":21}
172.28.10.4 - - [06/Jun/2026:12:03:43 +0000] "POST /api/log HTTP/1.1" 200 24 "-" "ESP32HTTPClient" "192.168.0.132"
[2026-06-06 13:03:55] production.WARNING: Failed to fetch data from URL <REDACTED>: cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for <REDACTED>
[2026-06-06 13:03:55] production.WARNING: Failed to fetch data from URL <REDACTED>: cURL error 28: Operation timed out after 30002 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for <REDACTED>
   INFO  No scheduled commands are ready to run.

[2026-06-06 13:04:00] production.INFO: Generated image: d021485c-a277-456e-bc18-ee5ee5d3c19f
[2026-06-06 13:04:00] production.INFO: Generated image: d021485c-a277-456e-bc18-ee5ee5d3c19f
[2026-06-06 13:04:00] production.INFO: Device 1: updated with new image: d021485c-a277-456e-bc18-ee5ee5d3c19f
[2026-06-06 13:04:00] production.INFO: Device 1: updated with new image: d021485c-a277-456e-bc18-ee5ee5d3c19f
```

Working backwards - we see the image generates after the curl times out at 30s at 13:03:55. This implies the request was made at 13:03:25. We then see the incoming log from the device at 12:03:41 that the read has timed out.

This tells us TRMNL has a 15s timeout for an image request. To fix this I've:

1. Added a timeout of 10s - this feels like a fairly safe window
2. Parallelized the HTTP requests within a single plugin for an easy performance win

There is the grander issue of a mash up still being able to hit this timeout as it could have up to 4x 10s time outs - but that's a larger architectural change I'm not comfortable making as a first PR. I would address that by either:
A. Making mashup generation happen/fetch data in parallel
B. Pre-fetching data in anticipation of a image request coming in
  




