### PR TITLE
feat: add user device models to preview selector

### DIFF
--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -130,7 +130,9 @@ new class extends Component
 
         // Set default preview device model
         if ($this->preview_device_model_id === null) {
-            $defaultModel = DeviceModel::where('name', 'og_plus')->first() ?? DeviceModel::first();
+            $defaultModel = $this->getUserDeviceModels()->first()
+                ?? DeviceModel::where('name', 'og_plus')->first()
+                ?? DeviceModel::first();
             $this->preview_device_model_id = $defaultModel?->id;
         }
     }
@@ -607,8 +609,17 @@ HTML;
 
     public function getDeviceModels()
     {
+        $groups = [];
+        $userDeviceModels = $this->getUserDeviceModels();
 
-        return [
+        if ($userDeviceModels->isNotEmpty()) {
+            $groups['user_devices'] = [
+                'label' => 'Your Devices',
+                'models' => $userDeviceModels,
+            ];
+        }
+
+        return $groups + [
             'trmnl' => [
                 'label' => 'TRMNL',
                 'models' => DeviceModel::whereKind('trmnl')->orderBy('label')->get(),
@@ -622,6 +633,20 @@ HTML;
                 'models' => DeviceModel::whereKind('kindle')->orderBy('label')->get(),
             ],
         ];
+    }
+
+    private function getUserDeviceModels()
+    {
+        return auth()->user()
+            ->devices()
+            ->with('deviceModel')
+            ->whereNotNull('device_model_id')
+            ->orderBy('id')
+            ->get()
+            ->pluck('deviceModel')
+            ->filter()
+            ->unique('id')
+            ->values();
     }
 
     public function updatedPreviewDeviceModelId(): void

--- a/tests/Feature/Livewire/Plugins/RecipePreviewModalTest.php
+++ b/tests/Feature/Livewire/Plugins/RecipePreviewModalTest.php
@@ -45,11 +45,12 @@ test('preview falls back to trmnl og when user has no device model', function ()
     $user = User::factory()->create();
     $this->actingAs($user);
 
-    $ogModel = DeviceModel::factory()->create([
-        'name' => 'og_plus',
-        'kind' => 'trmnl',
-        'label' => 'TRMNL OG (2-bit)',
-    ]);
+    $ogModel = DeviceModel::query()->firstWhere('name', 'og_plus')
+        ?? DeviceModel::factory()->create([
+            'name' => 'og_plus',
+            'kind' => 'trmnl',
+            'label' => 'TRMNL OG (2-bit)',
+        ]);
 
     $plugin = Plugin::factory()->create([
         'user_id' => $user->id,

--- a/tests/Feature/Livewire/Plugins/RecipePreviewModalTest.php
+++ b/tests/Feature/Livewire/Plugins/RecipePreviewModalTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Models\Device;
 use App\Models\DeviceModel;
 use App\Models\Plugin;
 use App\Models\User;
@@ -9,6 +10,58 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 
 uses(RefreshDatabase::class);
+
+test('preview defaults to the first registered device model', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $customDeviceModel = DeviceModel::factory()->create([
+        'kind' => null,
+        'label' => 'Seeed E1001 Monochrome (2bit)',
+        'width' => 800,
+        'height' => 480,
+    ]);
+
+    Device::factory()->create([
+        'user_id' => $user->id,
+        'device_model_id' => $customDeviceModel->id,
+    ]);
+
+    $plugin = Plugin::factory()->create([
+        'user_id' => $user->id,
+        'plugin_type' => 'recipe',
+        'data_strategy' => 'static',
+        'markup_language' => 'liquid',
+        'render_markup' => '<div class="title">Preview</div>',
+    ]);
+
+    Livewire::test('plugins.recipe', ['plugin' => $plugin])
+        ->assertSet('preview_device_model_id', $customDeviceModel->id)
+        ->assertSee('Your Devices')
+        ->assertSee('Seeed E1001 Monochrome (2bit)');
+});
+
+test('preview falls back to trmnl og when user has no device model', function (): void {
+    $user = User::factory()->create();
+    $this->actingAs($user);
+
+    $ogModel = DeviceModel::factory()->create([
+        'name' => 'og_plus',
+        'kind' => 'trmnl',
+        'label' => 'TRMNL OG (2-bit)',
+    ]);
+
+    $plugin = Plugin::factory()->create([
+        'user_id' => $user->id,
+        'plugin_type' => 'recipe',
+        'data_strategy' => 'static',
+        'markup_language' => 'liquid',
+        'render_markup' => '<div class="title">Preview</div>',
+    ]);
+
+    Livewire::test('plugins.recipe', ['plugin' => $plugin])
+        ->assertSet('preview_device_model_id', $ogModel->id);
+});
 
 test('render preview dispatches screen dimensions from selected device model', function (): void {
     $user = User::factory()->create();


### PR DESCRIPTION
Possible solution for #254.

Adds a `Your Devices` group to the recipe preview device-model dropdown.

The preview now prefers the first device model assigned to one of the current user's registered devices instead of always defaulting to `og_plus`. This also makes duplicated/custom device models show up in preview as long as they are assigned to a device.

Devices using `Custom (Manual Dimensions)` are not included, because they do not have a `device_model_id`.