### PR TITLE
Multi-user mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,6 +68,8 @@ VITE_APP_NAME="${APP_NAME}"
 TRMNL_PROXY_BASE_URL=https://trmnl.app
 TRMNL_PROXY_REFRESH_MINUTES=15
 REGISTRATION_ENABLED=1
+# Allow non-admin users to use Blade templates (arbitrary PHP execution). Dangerous in multi-user setups.
+# MULTI_USER_DANGEROUSLY_ALLOW_BLADE_TEMPLATES_FOR_NON_ADMINS=false
 
 # WebAuthn passkeys (Fortify). When false, passkey UI and routes are disabled.
 PASSKEYS_ENABLED=false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,8 +1,9 @@
 name: Build and Push Docker Images
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - '*'
 
 env:
   REGISTRY: ghcr.io
@@ -22,9 +23,6 @@ jobs:
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -40,16 +38,16 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ env.REGISTRY }}/usetrmnl/byos_laravel
-            ${{ env.REGISTRY }}/usetrmnl/larapaper
+            ${{ env.REGISTRY }}/spark-hpi/larapaper
           tags: |
             type=semver,pattern={{version}}
+            type=raw,value=latest
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ yarn-error.log
 /docs/node_modules
 /.envrc
 /.direnv
+/.worktrees

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ yarn-error.log
 /docs/node_modules
 /.envrc
 /.direnv
+

--- a/app/Actions/Api/ResolveDeviceByApiKey.php
+++ b/app/Actions/Api/ResolveDeviceByApiKey.php
@@ -41,8 +41,8 @@ class ResolveDeviceByApiKey
         return Device::create([
             'mac_address' => mb_strtoupper($macAddress),
             'api_key' => $accessToken ?? Str::random(22),
-            'user_id' => $autoAssignUser->id,
-            'name' => "{$autoAssignUser->name}'s TRMNL",
+            'user_id' => null,
+            'name' => 'Auto-Joined TRMNL',
             'friendly_id' => Str::random(6),
             'default_refresh_interval' => 900,
             'mirror_device_id' => $autoAssignUser->assign_new_device_id,

--- a/app/Actions/Api/ResolveDeviceByMacAddress.php
+++ b/app/Actions/Api/ResolveDeviceByMacAddress.php
@@ -44,8 +44,8 @@ class ResolveDeviceByMacAddress
         return Device::create([
             'mac_address' => mb_strtoupper($macAddress),
             'api_key' => Str::random(22),
-            'user_id' => $autoAssignUser->id,
-            'name' => "{$autoAssignUser->name}'s TRMNL",
+            'user_id' => null,
+            'name' => 'Auto-Joined TRMNL',
             'friendly_id' => Str::random(6),
             'default_refresh_interval' => 900,
             'mirror_device_id' => $autoAssignUser->assign_new_device_id,

--- a/app/Http/Controllers/Api/DisplayStatusController.php
+++ b/app/Http/Controllers/Api/DisplayStatusController.php
@@ -7,9 +7,12 @@ use App\Http\Requests\Api\DisplayStatusRequest;
 use App\Http\Requests\Api\UpdateDisplayStatusRequest;
 use App\Http\Resources\DeviceStatusResource;
 use App\Models\Device;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class DisplayStatusController extends Controller
 {
+    use AuthorizesRequests;
+
     public function show(DisplayStatusRequest $request): DeviceStatusResource
     {
         return new DeviceStatusResource($this->authorizedDevice($request));
@@ -26,8 +29,10 @@ class DisplayStatusController extends Controller
     private function authorizedDevice(DisplayStatusRequest|UpdateDisplayStatusRequest $request): Device
     {
         $deviceId = $request->integer('device_id');
-        abort_unless($request->user()->devices->contains($deviceId), 403);
+        $device = Device::findOrFail($deviceId);
 
-        return Device::findOrFail($deviceId);
+        $this->authorize('view', $device);
+
+        return $device;
     }
 }

--- a/app/Http/Controllers/Api/PluginArchiveController.php
+++ b/app/Http/Controllers/Api/PluginArchiveController.php
@@ -7,11 +7,13 @@ use App\Http\Requests\Api\ImportPluginArchiveRequest;
 use App\Models\Plugin;
 use App\Services\PluginExportService;
 use App\Services\PluginImportService;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class PluginArchiveController extends Controller
 {
+    use AuthorizesRequests;
     public function __construct(
         private PluginExportService $exporter,
         private PluginImportService $importer,
@@ -23,9 +25,9 @@ class PluginArchiveController extends Controller
             abort(400, 'trmnlp_id is required');
         }
 
-        $plugin = Plugin::where('trmnlp_id', $trmnlp_id)
-            ->where('user_id', auth()->id())
-            ->firstOrFail();
+        $plugin = Plugin::where('trmnlp_id', $trmnlp_id)->firstOrFail();
+
+        $this->authorize('view', $plugin);
 
         return $this->exporter->exportToZip($plugin, auth()->user());
     }

--- a/app/Http/Controllers/Api/PluginSettingsController.php
+++ b/app/Http/Controllers/Api/PluginSettingsController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
 use App\Models\Plugin;
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,6 +12,7 @@ use Symfony\Component\Uid\Uuid;
 
 class PluginSettingsController extends Controller
 {
+    use AuthorizesRequests;
     public function me(Request $request): JsonResponse
     {
         $user = $request->user();
@@ -54,10 +56,11 @@ class PluginSettingsController extends Controller
 
     public function destroy(Request $request, string $trmnlp_id): Response
     {
-        Plugin::where('trmnlp_id', $trmnlp_id)
-            ->where('user_id', $request->user()->id)
-            ->firstOrFail()
-            ->delete();
+        $plugin = Plugin::where('trmnlp_id', $trmnlp_id)->firstOrFail();
+
+        $this->authorize('delete', $plugin);
+
+        $plugin->delete();
 
         return response()->noContent();
     }

--- a/app/Http/Middleware/EnsureUserIsConfirmed.php
+++ b/app/Http/Middleware/EnsureUserIsConfirmed.php
@@ -13,7 +13,7 @@ class EnsureUserIsConfirmed
 {
     public function handle(Request $request, Closure $next): Response
     {
-        if ($request->user() && ! $request->user()->isConfirmed()) {
+        if (config('app.multi_user_mode') && $request->user() && ! $request->user()->isConfirmed()) {
             Auth::logout();
             $request->session()->invalidate();
             $request->session()->regenerateToken();

--- a/app/Http/Middleware/EnsureUserIsConfirmed.php
+++ b/app/Http/Middleware/EnsureUserIsConfirmed.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsureUserIsConfirmed
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if ($request->user() && ! $request->user()->isConfirmed()) {
+            Auth::logout();
+            $request->session()->invalidate();
+            $request->session()->regenerateToken();
+
+            return redirect()->route('login')
+                ->with('status', 'Your account is awaiting admin approval.');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/Actions/DeviceAutoJoin.php
+++ b/app/Livewire/Actions/DeviceAutoJoin.php
@@ -2,19 +2,16 @@
 
 namespace App\Livewire\Actions;
 
+use App\Models\User;
 use Livewire\Component;
 
 class DeviceAutoJoin extends Component
 {
     public bool $deviceAutojoin = false;
 
-    public bool $isFirstUser = false;
-
     public function mount(): void
     {
-        $this->deviceAutojoin = (bool) (auth()->user()->assign_new_devices ?? false);
-        $this->isFirstUser = auth()->user()->id === 1;
-
+        $this->deviceAutojoin = User::where('assign_new_devices', true)->exists();
     }
 
     public function updating($name, $value): void
@@ -24,9 +21,11 @@ class DeviceAutoJoin extends Component
         ]);
 
         if ($name === 'deviceAutojoin') {
-            auth()->user()->update([
-                'assign_new_devices' => $value,
-            ]);
+            if ($value) {
+                auth()->user()->update(['assign_new_devices' => true]);
+            } else {
+                User::where('assign_new_devices', true)->update(['assign_new_devices' => false]);
+            }
         }
     }
 

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -823,9 +823,11 @@ class Plugin extends Model
                     $renderedContent = $template->render($liquidContext);
                 }
             } else {
-                $isAdminOrAllowed = $this->user?->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
-                if (! $isAdminOrAllowed) {
-                    throw new \RuntimeException('Blade rendering is restricted to administrators. Switch the plugin to Liquid or contact an admin.');
+                if (config('app.multi_user_mode') && $this->user !== null) {
+                    $isAdminOrAllowed = $this->user->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
+                    if (! $isAdminOrAllowed) {
+                        throw new \RuntimeException('Blade rendering is restricted to administrators. Switch the plugin to Liquid or contact an admin.');
+                    }
                 }
 
                 // Get timezone from user or fall back to app timezone

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -19,6 +19,7 @@ use App\Services\PluginImportService;
 use Carbon\Carbon;
 use Closure;
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Client\Pool;
@@ -45,6 +46,7 @@ class Plugin extends Model
         'data_payload' => 'json',
         'data_payload_updated_at' => 'datetime',
         'is_native' => 'boolean',
+        'is_shared' => 'boolean',
         'markup_language' => 'string',
         'configuration' => 'json',
         'configuration_template' => 'json',
@@ -98,6 +100,18 @@ class Plugin extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function scopeVisibleTo(Builder $query, User $user): Builder
+    {
+        if ($user->isAdmin()) {
+            return $query;
+        }
+
+        return $query->where(function (Builder $q) use ($user): void {
+            $q->where('user_id', $user->id)
+              ->orWhere('is_shared', true);
+        });
     }
 
     /**

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -15,6 +15,7 @@ use App\Liquid\Tags\TemplateTag;
 use App\Plugins\PluginHandler;
 use App\Plugins\PluginRegistry;
 use App\Services\Plugin\Parsers\ResponseParserRegistry;
+use App\Services\Plugin\ServerlessTransformService;
 use App\Services\PluginImportService;
 use Carbon\Carbon;
 use Closure;
@@ -55,6 +56,8 @@ class Plugin extends Model
         'plugin_type' => 'string',
         'alias' => 'boolean',
         'current_image_metadata' => 'array',
+        'transform_code'         => 'string',   // add this
+        'transform_language'     => 'string',   // add this
     ];
 
     protected static function boot()
@@ -513,6 +516,11 @@ class Plugin extends Model
         if (! self::dataPayloadWithinWireLimit($finalPayload)) {
             Log::warning("Plugin {$this->id} data_payload exceeded wire size limit; storing error placeholder");
             $finalPayload = self::oversizedDataPayloadErrorPayload();
+        }
+
+        if ($this->transform_code && $this->transform_language) {
+            $finalPayload = app(ServerlessTransformService::class)
+                ->run($this->transform_code, $this->transform_language, $finalPayload);
         }
 
         $this->update([

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -823,6 +823,11 @@ class Plugin extends Model
                     $renderedContent = $template->render($liquidContext);
                 }
             } else {
+                $isAdminOrAllowed = $this->user?->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
+                if (! $isAdminOrAllowed) {
+                    throw new \RuntimeException('Blade rendering is restricted to administrators. Switch the plugin to Liquid or contact an admin.');
+                }
+
                 // Get timezone from user or fall back to app timezone
                 $timezone = $this->user->timezone ?? config('app.timezone');
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,8 @@ class User extends Authenticatable implements PasskeyUser // implements MustVeri
         'assign_new_device_id',
         'oidc_sub',
         'timezone',
+        'is_admin',
+        'confirmed_at',
     ];
 
     /**
@@ -56,6 +58,8 @@ class User extends Authenticatable implements PasskeyUser // implements MustVeri
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'assign_new_devices' => 'boolean',
+            'is_admin' => 'boolean',
+            'confirmed_at' => 'datetime',
         ];
     }
 
@@ -83,5 +87,39 @@ class User extends Authenticatable implements PasskeyUser // implements MustVeri
     public function routeNotificationForWebhook(): ?string
     {
         return config('services.webhook.notifications.url');
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this->id === 1 || $this->is_admin;
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this->confirmed_at !== null;
+    }
+
+    protected static function booted(): void
+    {
+        static::saving(function (User $user): void {
+            if ($user->id === 1) {
+                $user->is_admin = true;
+                if ($user->confirmed_at === null) {
+                    $user->confirmed_at = now();
+                }
+            }
+        });
+
+        static::created(function (User $user): void {
+            if ($user->id === 1) {
+                $updates = ['is_admin' => true];
+                if ($user->confirmed_at === null) {
+                    $updates['confirmed_at'] = now()->toDateTimeString();
+                }
+                \Illuminate\Support\Facades\DB::table('users')
+                    ->where('id', 1)
+                    ->update($updates);
+            }
+        });
     }
 }

--- a/app/Policies/DevicePolicy.php
+++ b/app/Policies/DevicePolicy.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Device;
+use App\Models\User;
+
+class DevicePolicy
+{
+    public function view(User $user, Device $device): bool
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        return $device->user_id === null || $device->user_id === $user->id;
+    }
+
+    public function update(User $user, Device $device): bool
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        return $device->user_id === null || $device->user_id === $user->id;
+    }
+
+    public function delete(User $user, Device $device): bool
+    {
+        return $this->update($user, $device);
+    }
+
+    public function reassign(User $user, Device $device): bool
+    {
+        return $user->isAdmin();
+    }
+}

--- a/app/Policies/PluginPolicy.php
+++ b/app/Policies/PluginPolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\Plugin;
+use App\Models\User;
+
+class PluginPolicy
+{
+    public function view(User $user, Plugin $plugin): bool
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        return $plugin->user_id === $user->id || $plugin->is_shared;
+    }
+
+    public function update(User $user, Plugin $plugin): bool
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        return $plugin->user_id === $user->id;
+    }
+
+    public function delete(User $user, Plugin $plugin): bool
+    {
+        return $this->update($user, $plugin);
+    }
+
+    public function share(User $user, Plugin $plugin): bool
+    {
+        return $user->isAdmin() || $plugin->user_id === $user->id;
+    }
+
+    public function reassign(User $user, Plugin $plugin): bool
+    {
+        return $user->isAdmin();
+    }
+
+    public function copy(User $user, Plugin $plugin): bool
+    {
+        return $plugin->is_shared || $user->isAdmin();
+    }
+}

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace App\Services\Plugin;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+
+class ServerlessTransformService
+{
+    private const DEFAULT_TIMEOUT = 30;
+
+    private const INTERPRETERS = [
+        'python' => 'python3',
+        'node'   => 'node',
+        'php'    => 'php',
+    ];
+
+    private const EXTENSIONS = [
+        'python' => 'py',
+        'node'   => 'js',
+        'php'    => 'php',
+    ];
+
+    public function run(string $code, string $language, array $input, ?int $timeout = null): array
+    {
+        if (! array_key_exists($language, self::INTERPRETERS)) {
+            Log::warning("ServerlessTransformService: unsupported language [{$language}]");
+
+            return $input;
+        }
+
+        $effectiveTimeout = $timeout ?? (int) env('TRANSFORM_TIMEOUT_SECONDS', self::DEFAULT_TIMEOUT);
+        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'trmnl-tx-'.bin2hex(random_bytes(8));
+        mkdir($tmpDir, 0700, true);
+
+        $scriptPath = $tmpDir.DIRECTORY_SEPARATOR.'transform.'.self::EXTENSIONS[$language];
+        $outputPath = $tmpDir.DIRECTORY_SEPARATOR.'output.json';
+
+        try {
+            file_put_contents($scriptPath, $this->buildHarness($language, $code, $outputPath));
+
+            $result = Process::input(json_encode($input))
+                ->timeout($effectiveTimeout)
+                ->run([self::INTERPRETERS[$language], $scriptPath]);
+
+            if (! $result->successful()) {
+                Log::warning('ServerlessTransformService: transform exited '.$result->exitCode().': '.trim($result->errorOutput()));
+
+                return $input;
+            }
+
+            if (! file_exists($outputPath)) {
+                Log::warning('ServerlessTransformService: transform produced no output file');
+
+                return $input;
+            }
+
+            $raw = file_get_contents($outputPath);
+            if ($raw === false || $raw === '') {
+                Log::warning('ServerlessTransformService: transform output file is empty');
+
+                return $input;
+            }
+
+            $decoded = json_decode($raw, true);
+            if (! is_array($decoded)) {
+                Log::warning('ServerlessTransformService: transform output is not a JSON object');
+
+                return $input;
+            }
+
+            return $decoded;
+        } catch (\Throwable $e) {
+            Log::warning('ServerlessTransformService: '.$e->getMessage());
+
+            return $input;
+        } finally {
+            $this->cleanupDir($tmpDir);
+        }
+    }
+
+    private function buildHarness(string $language, string $code, string $outputPath): string
+    {
+        return match ($language) {
+            'python' => $this->pythonHarness($code, $outputPath),
+            'node'   => $this->nodeHarness($code, $outputPath),
+            'php'    => $this->phpHarness($code, $outputPath),
+        };
+    }
+
+    private function pythonHarness(string $code, string $outputPath): string
+    {
+        $path = var_export($outputPath, true);
+
+        return implode("\n", [
+            'import sys, json',
+            'input = json.loads(sys.stdin.read())',
+            '',
+            $code,
+            '',
+            "if callable(locals().get('run', None)):",
+            '    output = run(input)',
+            "elif 'result' in dir():",
+            '    output = result',
+            'else:',
+            '    output = input',
+            "json.dump(output, open({$path}, 'w'))",
+        ]);
+    }
+
+    private function nodeHarness(string $code, string $outputPath): string
+    {
+        $path = json_encode($outputPath);
+
+        return "const input = JSON.parse(require('fs').readFileSync(0, 'utf8'));\n\n"
+            .$code
+            ."\n\nlet output;\n"
+            ."if (typeof run === 'function') {\n  output = run(input);\n"
+            ."} else if (typeof result !== 'undefined') {\n  output = result;\n"
+            ."} else {\n  output = input;\n}\n"
+            ."require('fs').writeFileSync({$path}, JSON.stringify(output));\n";
+    }
+
+    private function phpHarness(string $code, string $outputPath): string
+    {
+        $cleanedCode = preg_replace('/\A\s*<\?php\s*/u', '', $code);
+        $path = var_export($outputPath, true);
+
+        return "<?php\n"
+            ."\$input = json_decode(file_get_contents('php://stdin'), true);\n\n"
+            .$cleanedCode
+            ."\n\nif (function_exists('run')) {\n    \$output = run(\$input);\n"
+            ."} elseif (isset(\$result)) {\n    \$output = \$result;\n"
+            ."} else {\n    \$output = \$input;\n}\n"
+            ."file_put_contents({$path}, json_encode(\$output));\n";
+    }
+
+    private function cleanupDir(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            return;
+        }
+        foreach (glob($dir.DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
+            @unlink($file);
+        }
+        @rmdir($dir);
+    }
+}

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Log;
 
 class ServerlessTransformService
 {
-    public function run(string $code, string $language, array $input): array
+    public function run(string $code, string $language, array $input, bool $strict = false): array
     {
         $url = config('services.transform_runner.url');
         if (! $url) {
@@ -25,24 +25,32 @@ class ServerlessTransformService
             ]);
 
             if (! $response->successful()) {
-                Log::warning('ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''));
-
-                return $input;
+                return $this->fail(
+                    'ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''),
+                    $input,
+                    $strict
+                );
             }
 
             $output = $response->json('output');
             if (! is_array($output)) {
-                Log::warning('ServerlessTransformService: runner output is not a JSON object');
-
-                return $input;
+                return $this->fail('ServerlessTransformService: runner output is not a JSON object', $input, $strict);
             }
 
             return $output;
         } catch (\Throwable $e) {
-            Log::warning('ServerlessTransformService: '.$e->getMessage());
-
-            return $input;
+            return $this->fail('ServerlessTransformService: '.$e->getMessage(), $input, $strict);
         }
+    }
+
+    private function fail(string $message, array $input, bool $strict): array
+    {
+        if ($strict) {
+            throw new \RuntimeException($message);
+        }
+        Log::warning($message);
+
+        return $input;
     }
 
     public function isEnabled(): bool

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -2,147 +2,51 @@
 
 namespace App\Services\Plugin;
 
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
-use Illuminate\Support\Facades\Process;
 
 class ServerlessTransformService
 {
-    private const DEFAULT_TIMEOUT = 30;
-
-    private const INTERPRETERS = [
-        'python' => 'python3',
-        'node'   => 'node',
-        'php'    => 'php',
-    ];
-
-    private const EXTENSIONS = [
-        'python' => 'py',
-        'node'   => 'js',
-        'php'    => 'php',
-    ];
-
-    public function run(string $code, string $language, array $input, ?int $timeout = null): array
+    public function run(string $code, string $language, array $input): array
     {
-        if (! array_key_exists($language, self::INTERPRETERS)) {
-            Log::warning("ServerlessTransformService: unsupported language [{$language}]");
-
+        $url = config('services.transform_runner.url');
+        if (! $url) {
             return $input;
         }
 
-        $effectiveTimeout = $timeout ?? (int) env('TRANSFORM_TIMEOUT_SECONDS', self::DEFAULT_TIMEOUT);
-        $tmpDir = sys_get_temp_dir().DIRECTORY_SEPARATOR.'trmnl-tx-'.bin2hex(random_bytes(8));
-        mkdir($tmpDir, 0700, true);
-
-        $scriptPath = $tmpDir.DIRECTORY_SEPARATOR.'transform.'.self::EXTENSIONS[$language];
-        $outputPath = $tmpDir.DIRECTORY_SEPARATOR.'output.json';
+        $timeout = config('services.transform_runner.timeout', 30);
 
         try {
-            file_put_contents($scriptPath, $this->buildHarness($language, $code, $outputPath));
+            $response = Http::timeout($timeout)->post("{$url}/run", [
+                'language' => $language,
+                'code'     => $code,
+                'input'    => $input,
+                'timeout'  => $timeout,
+            ]);
 
-            $result = Process::input(json_encode($input))
-                ->timeout($effectiveTimeout)
-                ->run([self::INTERPRETERS[$language], $scriptPath]);
-
-            if (! $result->successful()) {
-                Log::warning('ServerlessTransformService: transform exited '.$result->exitCode().': '.trim($result->errorOutput()));
-
-                return $input;
-            }
-
-            if (! file_exists($outputPath)) {
-                Log::warning('ServerlessTransformService: transform produced no output file');
+            if (! $response->successful()) {
+                Log::warning('ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''));
 
                 return $input;
             }
 
-            $raw = file_get_contents($outputPath);
-            if ($raw === false || $raw === '') {
-                Log::warning('ServerlessTransformService: transform output file is empty');
+            $output = $response->json('output');
+            if (! is_array($output)) {
+                Log::warning('ServerlessTransformService: runner output is not a JSON object');
 
                 return $input;
             }
 
-            $decoded = json_decode($raw, true);
-            if (! is_array($decoded)) {
-                Log::warning('ServerlessTransformService: transform output is not a JSON object');
-
-                return $input;
-            }
-
-            return $decoded;
+            return $output;
         } catch (\Throwable $e) {
             Log::warning('ServerlessTransformService: '.$e->getMessage());
 
             return $input;
-        } finally {
-            $this->cleanupDir($tmpDir);
         }
     }
 
-    private function buildHarness(string $language, string $code, string $outputPath): string
+    public function isEnabled(): bool
     {
-        return match ($language) {
-            'python' => $this->pythonHarness($code, $outputPath),
-            'node'   => $this->nodeHarness($code, $outputPath),
-            'php'    => $this->phpHarness($code, $outputPath),
-        };
-    }
-
-    private function pythonHarness(string $code, string $outputPath): string
-    {
-        $path = var_export($outputPath, true);
-
-        return implode("\n", [
-            'import sys, json',
-            'input = json.loads(sys.stdin.read())',
-            '',
-            $code,
-            '',
-            "if callable(locals().get('run', None)):",
-            '    output = run(input)',
-            "elif 'result' in dir():",
-            '    output = result',
-            'else:',
-            '    output = input',
-            "json.dump(output, open({$path}, 'w'))",
-        ]);
-    }
-
-    private function nodeHarness(string $code, string $outputPath): string
-    {
-        $path = json_encode($outputPath);
-
-        return "const input = JSON.parse(require('fs').readFileSync(0, 'utf8'));\n\n"
-            .$code
-            ."\n\nlet output;\n"
-            ."if (typeof run === 'function') {\n  output = run(input);\n"
-            ."} else if (typeof result !== 'undefined') {\n  output = result;\n"
-            ."} else {\n  output = input;\n}\n"
-            ."require('fs').writeFileSync({$path}, JSON.stringify(output));\n";
-    }
-
-    private function phpHarness(string $code, string $outputPath): string
-    {
-        $cleanedCode = preg_replace('/\A\s*<\?php\s*/u', '', $code);
-        $path = var_export($outputPath, true);
-
-        return "<?php\n"
-            ."\$input = json_decode(file_get_contents('php://stdin'), true);\n\n"
-            .$cleanedCode
-            ."\n\nif (function_exists('run')) {\n    \$output = run(\$input);\n"
-            ."} elseif (isset(\$result)) {\n    \$output = \$result;\n"
-            ."} else {\n    \$output = \$input;\n}\n"
-            ."file_put_contents({$path}, json_encode(\$output));\n";
-    }
-
-    private function cleanupDir(string $dir): void
-    {
-        if (! is_dir($dir)) {
-            return;
-        }
-        foreach (glob($dir.DIRECTORY_SEPARATOR.'*') ?: [] as $file) {
-            @unlink($file);
-        }
-        @rmdir($dir);
+        return (bool) config('services.transform_runner.url');
     }
 }

--- a/app/Services/Plugin/ServerlessTransformService.php
+++ b/app/Services/Plugin/ServerlessTransformService.php
@@ -25,21 +25,38 @@ class ServerlessTransformService
             ]);
 
             if (! $response->successful()) {
-                return $this->fail(
-                    'ServerlessTransformService: runner returned '.$response->status().': '.$response->json('error', ''),
-                    $input,
-                    $strict
-                );
+                $msg = 'runner returned '.$response->status().': '.$response->json('error', $response->body());
+                if ($strict) {
+                    throw new \RuntimeException($msg);
+                }
+                Log::warning('ServerlessTransformService: '.$msg);
+
+                return ['error' => $msg];
             }
 
             $output = $response->json('output');
-            if (! is_array($output)) {
-                return $this->fail('ServerlessTransformService: runner output is not a JSON object', $input, $strict);
+            if (is_array($output)) {
+                return $output;
             }
 
-            return $output;
+            // Runner returned an error body (e.g. {"error": "..."}) — store it as the payload.
+            $runnerBody = $response->json();
+            if (is_array($runnerBody)) {
+                if ($strict) {
+                    throw new \RuntimeException($runnerBody['error'] ?? 'transform runner returned no output');
+                }
+
+                return $runnerBody;
+            }
+
+            return $this->fail('ServerlessTransformService: runner returned no output', $input, $strict);
         } catch (\Throwable $e) {
-            return $this->fail('ServerlessTransformService: '.$e->getMessage(), $input, $strict);
+            if ($strict) {
+                throw new \RuntimeException('ServerlessTransformService: '.$e->getMessage(), previous: $e);
+            }
+            Log::warning('ServerlessTransformService: '.$e->getMessage());
+
+            return ['error' => $e->getMessage()];
         }
     }
 

--- a/app/Services/PluginImportService.php
+++ b/app/Services/PluginImportService.php
@@ -644,6 +644,13 @@ class PluginImportService
                         $quadrantLiquidPath = $newSrcDir.'/quadrant.'.$extension;
                     }
 
+                    foreach (['py', 'js', 'php'] as $transformExt) {
+                        $origTransformPath = $srcDir.'/transform.'.$transformExt;
+                        if (File::exists($origTransformPath)) {
+                            File::copy($origTransformPath, $newSrcDir.'/transform.'.$transformExt);
+                        }
+                    }
+
                     // Update the paths
                     $settingsYamlPath = $newSrcDir.'/settings.yml';
                 }

--- a/app/Services/PluginImportService.php
+++ b/app/Services/PluginImportService.php
@@ -90,6 +90,23 @@ class PluginImportService
         $settings = Yaml::parse(count($yamlParts) > 1 ? $yamlParts[1] : $settingsYaml);
         $this->validateYAML($settings);
 
+        $transformCode = null;
+        $transformLanguage = null;
+        $serverlessLanguage = ! empty($settings['serverless_language'])
+            ? strtolower((string) $settings['serverless_language'])
+            : null;
+
+        if ($serverlessLanguage) {
+            $extMap = ['python' => 'py', 'node' => 'js', 'php' => 'php'];
+            $ext = $extMap[$serverlessLanguage] ?? null;
+            $srcDir = dirname((string) $filePaths['settingsYamlPath']);
+
+            if ($ext && File::exists($srcDir.'/transform.'.$ext)) {
+                $transformCode = File::get($srcDir.'/transform.'.$ext);
+                $transformLanguage = $serverlessLanguage;
+            }
+        }
+
         // Determine markup language from the first available file
         $markupLanguage = 'blade';
         $firstTemplatePath = $filePaths['fullLiquidPath']
@@ -185,6 +202,8 @@ class PluginImportService
                 'configuration_template' => $configurationTemplate,
                 'data_payload' => json_decode($settings['static_data'] ?? '{}', true),
                 'framework_version' => $settings['framework_version'] ?? null,
+                'transform_code'     => $transformCode,
+                'transform_language' => $transformLanguage,
             ]);
 
         if (! $plugin_updated) {
@@ -259,6 +278,23 @@ class PluginImportService
         $yamlParts = preg_split('/^---[ \t]*\r?\n/m', $settingsYaml, 2);
         $settings = Yaml::parse(count($yamlParts) > 1 ? $yamlParts[1] : $settingsYaml);
         $this->validateYAML($settings);
+
+        $transformCode = null;
+        $transformLanguage = null;
+        $serverlessLanguage = ! empty($settings['serverless_language'])
+            ? strtolower((string) $settings['serverless_language'])
+            : null;
+
+        if ($serverlessLanguage) {
+            $extMap = ['python' => 'py', 'node' => 'js', 'php' => 'php'];
+            $ext = $extMap[$serverlessLanguage] ?? null;
+            $srcDir = dirname((string) $filePaths['settingsYamlPath']);
+
+            if ($ext && File::exists($srcDir.'/transform.'.$ext)) {
+                $transformCode = File::get($srcDir.'/transform.'.$ext);
+                $transformLanguage = $serverlessLanguage;
+            }
+        }
 
         // Determine markup language from the first available file
         $markupLanguage = 'blade';
@@ -367,6 +403,8 @@ class PluginImportService
                 'preferred_renderer' => $preferredRenderer,
                 'framework_version' => $settings['framework_version'] ?? null,
                 'icon_url' => $iconUrl,
+                'transform_code'     => $transformCode,
+                'transform_language' => $transformLanguage,
             ]);
 
         if (! $plugin_updated) {

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -17,6 +17,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->alias([
             'abilities' => CheckAbilities::class,
             'ability' => CheckForAnyAbility::class,
+            'confirmed' => \App\Http\Middleware\EnsureUserIsConfirmed::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/config/app.php
+++ b/config/app.php
@@ -127,6 +127,8 @@ return [
         'enabled' => env('REGISTRATION_ENABLED', true),
     ],
 
+    'multi_user_mode' => env('MULTI_USER_MODE', env('REGISTRATION_ENABLED', true)),
+
     /*
     |--------------------------------------------------------------------------
     | Passkeys (PASSKEYS_ENABLED)

--- a/config/app.php
+++ b/config/app.php
@@ -146,6 +146,7 @@ return [
 
     'force_https' => env('FORCE_HTTPS', false),
     'puppeteer_docker' => env('PUPPETEER_DOCKER', false),
+    'docker' => env('APP_DOCKER', file_exists('/.dockerenv')),
     'puppeteer_mode' => env('PUPPETEER_MODE', 'local'),
     'puppeteer_wait_for_network_idle' => env('PUPPETEER_WAIT_FOR_NETWORK_IDLE', true),
     'puppeteer_window_size_strategy' => env('PUPPETEER_WINDOW_SIZE_STRATEGY', 'v2'),

--- a/config/app.php
+++ b/config/app.php
@@ -129,6 +129,8 @@ return [
 
     'multi_user_mode' => env('MULTI_USER_MODE', env('REGISTRATION_ENABLED', true)),
 
+    'dangerously_allow_blade_for_non_admins' => env('MULTI_USER_DANGEROUSLY_ALLOW_BLADE_TEMPLATES_FOR_NON_ADMINS', false),
+
     /*
     |--------------------------------------------------------------------------
     | Passkeys (PASSKEYS_ENABLED)

--- a/config/services.php
+++ b/config/services.php
@@ -65,4 +65,9 @@ return [
         'scopes' => explode(',', env('OIDC_SCOPES', 'openid,profile,email')),
     ],
 
+    'transform_runner' => [
+        'url'     => env('TRANSFORM_RUNNER_URL'),
+        'timeout' => (int) env('TRANSFORM_TIMEOUT_SECONDS', 30),
+    ],
+
 ];

--- a/database/factories/PluginFactory.php
+++ b/database/factories/PluginFactory.php
@@ -30,6 +30,7 @@ class PluginFactory extends Factory
             'flux_icon_name' => null,
             'author_name' => $this->faker->name(),
             'plugin_type' => 'recipe',
+            'is_shared' => false,
             'created_at' => Carbon::now(),
             'updated_at' => Carbon::now(),
         ];

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -32,6 +32,8 @@ class UserFactory extends Factory
             'two_factor_secret' => null,
             'two_factor_recovery_codes' => null,
             'two_factor_confirmed_at' => null,
+            'confirmed_at' => now(),
+            'is_admin' => false,
         ];
     }
 
@@ -54,6 +56,28 @@ class UserFactory extends Factory
             'two_factor_secret' => encrypt('secret'),
             'two_factor_recovery_codes' => encrypt(json_encode(['recovery-code-1'])),
             'two_factor_confirmed_at' => now(),
+        ]);
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_admin' => true,
+            'confirmed_at' => now(),
+        ]);
+    }
+
+    public function confirmed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'confirmed_at' => now(),
+        ]);
+    }
+
+    public function unconfirmed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'confirmed_at' => null,
         ]);
     }
 }

--- a/database/migrations/2026_06_25_000001_add_admin_columns_to_users_table.php
+++ b/database/migrations/2026_06_25_000001_add_admin_columns_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+// database/migrations/2026_06_25_000001_add_admin_columns_to_users_table.php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->boolean('is_admin')->default(false)->after('remember_token');
+            $table->timestamp('confirmed_at')->nullable()->after('is_admin');
+        });
+
+        // All existing users are confirmed (no one gets locked out on upgrade)
+        DB::table('users')->update(['confirmed_at' => now()]);
+
+        // First user is always admin
+        DB::table('users')->where('id', 1)->update(['is_admin' => true]);
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->dropColumn(['is_admin', 'confirmed_at']);
+        });
+    }
+};

--- a/database/migrations/2026_06_25_000002_add_is_shared_to_plugins_table.php
+++ b/database/migrations/2026_06_25_000002_add_is_shared_to_plugins_table.php
@@ -1,0 +1,24 @@
+<?php
+// database/migrations/2026_06_25_000002_add_is_shared_to_plugins_table.php
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('plugins', function (Blueprint $table): void {
+            $table->boolean('is_shared')->default(false)->after('user_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('plugins', function (Blueprint $table): void {
+            $table->dropColumn('is_shared');
+        });
+    }
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,22 @@ services:
             - PHP_OPCACHE_ENABLE=1
             - TRMNL_PROXY_REFRESH_MINUTES=15
             - DB_DATABASE=database/storage/database.sqlite
+            - TRANSFORM_RUNNER_URL=http://transform-runner:3000
         volumes:
            - database:/var/www/html/database/storage
            - storage:/var/www/html/storage/app/public/images/generated
         restart: unless-stopped
+        depends_on:
+            - transform-runner
         #platform: "linux/arm64/v8"
+
+    transform-runner:
+        build:
+            context: ./runner
+            dockerfile: Dockerfile
+        restart: unless-stopped
+        #platform: "linux/arm64/v8"
+
 volumes:
     database:
     storage:
-

--- a/docs/docmd.config.js
+++ b/docs/docmd.config.js
@@ -85,6 +85,7 @@ export default defineConfig({
       collapsible: true,
       children: [
         { title: 'Generating screens', path: '/usage/generating-screens', icon: 'image' },
+        { title: 'Multi-user mode', path: '/usage/multi-user', icon: 'users' },
         { title: 'Cloud proxy', path: '/usage/cloud-proxy', icon: 'cloud' },
         { title: 'Demo plugins', path: '/usage/demo-plugins', icon: 'puzzle' },
       ],

--- a/docs/docs/getting-started/environment-variables.md
+++ b/docs/docs/getting-started/environment-variables.md
@@ -10,6 +10,8 @@ description: LaraPaper environment configuration reference.
 | `TRMNL_PROXY_BASE_URL` | Base URL of the native TRMNL service | `https://trmnl.app` |
 | `TRMNL_PROXY_REFRESH_MINUTES` | How often to fetch new images from the cloud service | `15` |
 | `REGISTRATION_ENABLED` | Allow registration via the web UI | `1` |
+| `MULTI_USER_MODE` | Enable multi-user mode (account confirmation, per-user ownership) | `REGISTRATION_ENABLED` |
+| `MULTI_USER_DANGEROUSLY_ALLOW_BLADE_TEMPLATES_FOR_NON_ADMINS` | Allow non-admin users to use Blade templates (arbitrary PHP) | `false` |
 | `PASSKEYS_ENABLED` | Enable passkeys (requires HTTPS) | `0` |
 | `SSL_MODE` | SSL mode when not behind a reverse proxy ([docs](https://serversideup.net/open-source/docker-php/docs/customizing-the-image/configuring-ssl)) | `off` |
 | `FORCE_HTTPS` | Enforce HTTPS when the server terminates SSL | `0` |

--- a/docs/docs/usage/multi-user.md
+++ b/docs/docs/usage/multi-user.md
@@ -1,0 +1,81 @@
+---
+title: Multi-user mode
+description: Run LaraPaper with multiple users, admin approval, and per-user device and plugin ownership.
+---
+
+# Multi-user mode
+
+Multi-user mode lets multiple people share a single LaraPaper instance. Each user owns their own devices and plugins, admins oversee the whole installation.
+
+## Enabling
+
+Set `MULTI_USER_MODE=true` in your environment (or set `REGISTRATION_ENABLED=1`, which implies multi-user mode).
+
+```env
+MULTI_USER_MODE=true
+```
+
+When disabled (default for single-user installs), all access controls and confirmation flows are bypassed.
+
+## Roles
+
+| Role | How assigned |
+|---|---|
+| **Primary admin** | The first registered user (ID = 1). Cannot be deleted or demoted. |
+| **Admin** | Any user promoted via the User Management page. |
+| **User** | Everyone else. Must be confirmed by an admin before they can log in. |
+
+## Account confirmation
+
+New registrations are **pending** until an admin confirms them. A pending user who tries to log in is logged out with the message _"Your account is awaiting admin approval."_
+
+Admins manage accounts at **Settings → User Management**:
+
+- **Confirm** — grants access
+- **Revoke** — removes access without deleting the account
+- **Promote to admin** — grants admin privileges
+- **Remove admin** — demotes to regular user (primary admin is protected)
+- **Delete** — permanently removes the account
+
+## Device ownership
+
+- **Unowned devices** are visible to all users and can be claimed by anyone.
+- Each device can be assigned to one user. Owners (and admins) can configure and delete their devices.
+- Admins see a **Show all devices** toggle on the Devices page to view every device across all users.
+- Admins can **reassign** a device to a different user from the device detail page.
+
+## Plugin (recipe) ownership
+
+- Users see only their own plugins by default.
+- Admins see a **Show all plugins** toggle to view plugins across all users.
+- Admins can **reassign** a plugin to a different user from the plugin detail page.
+
+### Shared plugins
+
+Any user can share their own recipe plugins. Shared plugins appear in the **Shared** tab for all users, who can then **copy** them to their own account.
+
+## Template language restrictions
+
+Blade templates execute arbitrary PHP and are unsafe for untrusted users. In multi-user mode, **only admins can use Blade**; regular users are limited to **Liquid** (sandboxed).
+
+This applies to:
+- The template language selector in the recipe editor
+- The **Plugins → Markup** page
+- Recipe rendering at screen generation time
+
+To allow non-admins to use Blade (e.g. on a trusted private instance), set:
+
+```env
+MULTI_USER_DANGEROUSLY_ALLOW_BLADE_TEMPLATES_FOR_NON_ADMINS=true
+```
+
+::: warning
+Enabling this gives non-admin users the ability to execute arbitrary PHP on the server. Only use it when all users are trusted.
+:::
+
+## Environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `MULTI_USER_MODE` | Enable multi-user mode | `REGISTRATION_ENABLED` |
+| `MULTI_USER_DANGEROUSLY_ALLOW_BLADE_TEMPLATES_FOR_NON_ADMINS` | Allow non-admins to use Blade templates | `false` |

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
     "requires": true,
     "packages": {
         "": {
-            "name": "larapaper",
             "dependencies": {
                 "@codemirror/commands": "^6.9.0",
                 "@codemirror/lang-css": "^6.3.1",
@@ -12,6 +11,8 @@
                 "@codemirror/lang-javascript": "^6.2.4",
                 "@codemirror/lang-json": "^6.0.2",
                 "@codemirror/lang-liquid": "^6.3.0",
+                "@codemirror/lang-php": "^6.0.2",
+                "@codemirror/lang-python": "^6.2.1",
                 "@codemirror/lang-yaml": "^6.1.2",
                 "@codemirror/language": "^6.11.3",
                 "@codemirror/search": "^6.5.11",
@@ -151,6 +152,32 @@
                 "@lezer/common": "^1.0.0",
                 "@lezer/highlight": "^1.0.0",
                 "@lezer/lr": "^1.3.1"
+            }
+        },
+        "node_modules/@codemirror/lang-php": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.2.tgz",
+            "integrity": "sha512-ZKy2v1n8Fc8oEXj0Th0PUMXzQJ0AIR6TaZU+PbDHExFwdu+guzOA4jmCHS1Nz4vbFezwD7LyBdDnddSJeScMCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/lang-html": "^6.0.0",
+                "@codemirror/language": "^6.0.0",
+                "@codemirror/state": "^6.0.0",
+                "@lezer/common": "^1.0.0",
+                "@lezer/php": "^1.0.0"
+            }
+        },
+        "node_modules/@codemirror/lang-python": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-python/-/lang-python-6.2.1.tgz",
+            "integrity": "sha512-IRjC8RUBhn9mGR9ywecNhB51yePWCGgvHfY1lWN/Mrp3cKuHr0isDKia+9HnvhiWNnMpbGhWrkhuWOc09exRyw==",
+            "license": "MIT",
+            "dependencies": {
+                "@codemirror/autocomplete": "^6.3.2",
+                "@codemirror/language": "^6.8.0",
+                "@codemirror/state": "^6.0.0",
+                "@lezer/common": "^1.2.1",
+                "@lezer/python": "^1.1.4"
             }
         },
         "node_modules/@codemirror/lang-yaml": {
@@ -419,6 +446,28 @@
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.0.0"
+            }
+        },
+        "node_modules/@lezer/php": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@lezer/php/-/php-1.0.5.tgz",
+            "integrity": "sha512-W7asp9DhM6q0W6DYNwIkLSKOvxlXRrif+UXBMxzsJUuqmhE7oVU+gS3THO4S/Puh7Xzgm858UNaFi6dxTP8dJA==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.2.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.1.0"
+            }
+        },
+        "node_modules/@lezer/python": {
+            "version": "1.1.19",
+            "resolved": "https://registry.npmjs.org/@lezer/python/-/python-1.1.19.tgz",
+            "integrity": "sha512-MhQIURHRytsNzP/YXnqpYKW6la6voAH3kyplTOOiCdjyFY6cWWGFVmYVdHIPrElqSDf4iCDktQCockB9FxuhzQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@lezer/common": "^1.2.0",
+                "@lezer/highlight": "^1.0.0",
+                "@lezer/lr": "^1.0.0"
             }
         },
         "node_modules/@lezer/yaml": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
         "@codemirror/lang-javascript": "^6.2.4",
         "@codemirror/lang-json": "^6.0.2",
         "@codemirror/lang-liquid": "^6.3.0",
+        "@codemirror/lang-php": "^6.0.2",
+        "@codemirror/lang-python": "^6.2.1",
         "@codemirror/lang-yaml": "^6.1.2",
         "@codemirror/language": "^6.11.3",
         "@codemirror/search": "^6.5.11",

--- a/resources/js/codemirror-core.js
+++ b/resources/js/codemirror-core.js
@@ -10,6 +10,8 @@ import { json } from '@codemirror/lang-json';
 import { css } from '@codemirror/lang-css';
 import { liquid } from '@codemirror/lang-liquid';
 import { yaml } from '@codemirror/lang-yaml';
+import { python } from '@codemirror/lang-python';
+import { php } from '@codemirror/lang-php';
 import { oneDark } from '@codemirror/theme-one-dark';
 import { githubLight } from '@fsegurai/codemirror-theme-github-light';
 
@@ -23,6 +25,9 @@ const LANGUAGE_MAP = {
     'html': html,
     'yaml': yaml,
     'yml': yaml,
+    'python': python,
+    'py': python,
+    'php': php,
 };
 
 // Theme support mapping

--- a/resources/views/layouts/app/header.blade.php
+++ b/resources/views/layouts/app/header.blade.php
@@ -71,7 +71,7 @@
                 <flux:menu.item href="{{ route('settings.preferences') }}" wire:navigate icon="cog">Settings</flux:menu.item>
                 <flux:menu.item href="{{ route('settings.api-tokens') }}" wire:navigate icon="key">API Tokens</flux:menu.item>
                 <flux:menu.item href="{{ route('settings.lab') }}" wire:navigate icon="beaker">Lab</flux:menu.item>
-                @if(config('app.version'))
+                @if(config('app.version') && !config('app.docker'))
                     <flux:menu.item href="{{ route('settings.update') }}" wire:navigate icon="arrow-down-circle">
                         <div class="flex items-center gap-2">
                             <span>Updates</span>

--- a/resources/views/livewire/actions/device-auto-join.blade.php
+++ b/resources/views/livewire/actions/device-auto-join.blade.php
@@ -1,7 +1,5 @@
 <div>
-    @if($isFirstUser)
-        <flux:tooltip content="Add devices automatically that try to connect to this server" position="bottom">
-            <flux:switch wire:model.live="deviceAutojoin" label="Permit Auto-Join"/>
-        </flux:tooltip>
-    @endif
+    <flux:tooltip content="Add devices automatically that try to connect to this server" position="bottom">
+        <flux:switch wire:model.live="deviceAutojoin" label="Permit Auto-Join"/>
+    </flux:tooltip>
 </div>

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -77,7 +77,7 @@ new class extends Component
 
     public function mount(App\Models\Device $device)
     {
-        abort_unless(auth()->user()->devices->contains($device), 403);
+        $this->authorize('update', $device);
 
         $current_image_uuid = $device->current_screen_image;
         $current_image_path = 'images/generated/'.$current_image_uuid.'.png';
@@ -138,7 +138,7 @@ new class extends Component
 
     public function deleteDevice(App\Models\Device $device)
     {
-        abort_unless(auth()->user()->devices->contains($device), 403);
+        $this->authorize('delete', $device);
         $device->delete();
 
         redirect()->route('devices');
@@ -165,7 +165,7 @@ new class extends Component
 
     public function updateDevice()
     {
-        abort_unless(auth()->user()->devices->contains($this->device), 403);
+        $this->authorize('update', $this->device);
 
         $this->validate([
             'name' => 'required|string|max:255',
@@ -260,7 +260,7 @@ new class extends Component
     public function sortPlaylistItem(int $id, int $position): void
     {
         $item = PlaylistItem::query()->with('playlist.device')->findOrFail($id);
-        abort_unless(auth()->user()->devices->contains($item->playlist->device), 403);
+        $this->authorize('update', $item->playlist->device);
 
         $items = $item->playlist->items()->orderBy('order')->orderBy('id')->get();
         $ids = $items->pluck('id')->all();
@@ -288,7 +288,7 @@ new class extends Component
 
     public function deletePlaylist(Playlist $playlist)
     {
-        abort_unless(auth()->user()->devices->contains($playlist->device), 403);
+        $this->authorize('update', $playlist->device);
         $playlist->delete();
         $this->playlists = $this->device->playlists()->with('items.plugin')->orderBy('created_at')->get();
         Flux::modal('delete-playlist-'.$playlist->id)->close();
@@ -296,7 +296,7 @@ new class extends Component
 
     public function deletePlaylistItem(PlaylistItem $item)
     {
-        abort_unless(auth()->user()->devices->contains($item->playlist->device), 403);
+        $this->authorize('update', $item->playlist->device);
         $item->delete();
         $this->playlists = $this->device->playlists()->with('items.plugin')->orderBy('created_at')->get();
         Flux::modal('delete-playlist-item-'.$item->id)->close();
@@ -306,7 +306,7 @@ new class extends Component
     {
         $item->loadMissing(['playlist.device', 'plugin']);
 
-        abort_unless(auth()->user()->devices->contains($item->playlist->device), 403);
+        $this->authorize('update', $item->playlist->device);
 
         if ($item->isMashup()) {
             return;
@@ -373,7 +373,7 @@ new class extends Component
 
     public function updateFirmware()
     {
-        abort_unless(auth()->user()->devices->contains($this->device), 403);
+        $this->authorize('update', $this->device);
 
         $this->validate([
             'selected_firmware_id' => 'required|exists:firmware,id',

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -10,6 +10,8 @@ use Livewire\Component;
 
 new class extends Component
 {
+    use \Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
     private const DEFAULT_SLEEP_MODE_FROM = '22:00';
 
     private const DEFAULT_SLEEP_MODE_TO = '06:00';
@@ -74,6 +76,18 @@ new class extends Component
     public $selected_firmware_id;
 
     public $download_firmware;
+
+    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
+    {
+        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
+    }
+
+    public function reassignDevice(?int $newOwnerId): void
+    {
+        $this->authorize('reassign', $this->device);
+        $this->device->update(['user_id' => $newOwnerId]);
+        Flux::toast(variant: 'success', text: 'Device ownership updated.');
+    }
 
     public function mount(App\Models\Device $device)
     {
@@ -541,6 +555,19 @@ new class extends Component
                                 <flux:input type="time" label="From" wire:model.fill="sleep_mode_from"/>
                                 <flux:input type="time" label="To" wire:model.fill="sleep_mode_to" />
                             </div>
+                        @endif
+
+                        @if(auth()->user()->isAdmin())
+                            <flux:separator class="my-4" text="Admin" />
+                            <flux:select label="Owner"
+                                         wire:change="reassignDevice($event.target.value ? Number($event.target.value) : null)">
+                                <flux:select.option value="">Nobody (Unowned)</flux:select.option>
+                                @foreach ($this->availableUsers as $u)
+                                    <flux:select.option value="{{ $u->id }}" :selected="$device->user_id === $u->id">
+                                        {{ $u->name }}
+                                    </flux:select.option>
+                                @endforeach
+                            </flux:select>
                         @endif
 
                         <div class="flex">

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -557,7 +557,7 @@ new class extends Component
                             </div>
                         @endif
 
-                        @if(auth()->user()->isAdmin())
+                        @if(config('app.multi_user_mode') && auth()->user()->isAdmin())
                             <flux:separator class="my-4" text="Admin" />
                             <flux:select label="Owner"
                                          wire:change="reassignDevice($event.target.value ? Number($event.target.value) : null)">

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -73,12 +73,13 @@ new class extends Component
         $this->loadDevices();
     }
 
-    public function reassignDevice(int $deviceId, ?int $newOwnerId): void
+    public function reassignDevice(int $deviceId, $newOwnerId = null): void
     {
         $device = Device::findOrFail($deviceId);
         $this->authorize('reassign', $device);
 
-        $device->update(['user_id' => $newOwnerId]);
+        $ownerId = ($newOwnerId === '' || $newOwnerId === null) ? null : (int) $newOwnerId;
+        $device->update(['user_id' => $ownerId]);
         $this->loadDevices();
 
         Flux::toast(variant: 'success', text: 'Device ownership updated.');
@@ -298,7 +299,7 @@ new class extends Component
                         @if (config('app.multi_user_mode') && auth()->user()->isAdmin())
                             <td class="py-3 px-3 first:pl-0 last:pr-0 text-sm whitespace-nowrap text-zinc-500 dark:text-zinc-300">
                                 <flux:select
-                                    wire:change="reassignDevice({{ $device->id }}, $event.target.value ? Number($event.target.value) : null)"
+                                    wire:change="reassignDevice({{ $device->id }}, $event.target.value)"
                                     class="text-xs"
                                 >
                                     <flux:select.option value="" :selected="$device->user_id === null">

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -73,22 +73,6 @@ new class extends Component
         $this->loadDevices();
     }
 
-    public function reassignDevice(int $deviceId, ?int $newOwnerId): void
-    {
-        $device = Device::findOrFail($deviceId);
-        $this->authorize('reassign', $device);
-
-        $device->update(['user_id' => $newOwnerId]);
-        $this->loadDevices();
-
-        Flux::toast(variant: 'success', text: 'Device ownership updated.');
-    }
-
-    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
-    {
-        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
-    }
-
     public function updatedDeviceModelId(): void
     {
         // Convert empty string to null for custom selection
@@ -169,8 +153,9 @@ new class extends Component
                 </flux:modal.trigger>
             </div>
             @if (auth()->user()->isAdmin())
-                <div class="mb-4">
-                    <flux:switch wire:model.live="showAllDevices" label="Show all users' devices"/>
+                <div class="mb-4 flex items-center gap-2">
+                    <flux:switch wire:model.live="showAllDevices" />
+                    <span class="text-sm font-medium dark:text-zinc-200">Show all users' devices</span>
                 </div>
             @endif
             <flux:modal name="create-device" class="md:w-96">
@@ -330,17 +315,6 @@ new class extends Component
                                                  :disabled="$device->mirror_device_id !== null"
                                                  label="☁️ Proxy"/>
                                 </flux:tooltip>
-                                @if (auth()->user()->isAdmin())
-                                    <flux:select wire:change="reassignDevice({{ $device->id }}, $event.target.value ? Number($event.target.value) : null)"
-                                                 class="text-xs">
-                                        <flux:select.option value="">Nobody</flux:select.option>
-                                        @foreach ($this->availableUsers as $u)
-                                            <flux:select.option value="{{ $u->id }}" :selected="$device->user_id === $u->id">
-                                                {{ $u->name }}
-                                            </flux:select.option>
-                                        @endforeach
-                                    </flux:select>
-                                @endif
                             </div>
                         </td>
                     </tr>

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -73,6 +73,22 @@ new class extends Component
         $this->loadDevices();
     }
 
+    public function reassignDevice(int $deviceId, ?int $newOwnerId): void
+    {
+        $device = Device::findOrFail($deviceId);
+        $this->authorize('reassign', $device);
+
+        $device->update(['user_id' => $newOwnerId]);
+        $this->loadDevices();
+
+        Flux::toast(variant: 'success', text: 'Device ownership updated.');
+    }
+
+    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
+    {
+        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
+    }
+
     public function updatedDeviceModelId(): void
     {
         // Convert empty string to null for custom selection
@@ -244,6 +260,12 @@ new class extends Component
                         data-flux-column="">
                         <div class="whitespace-nowrap flex group-[]/right-align:justify-end">Name</div>
                     </th>
+                    @if (config('app.multi_user_mode') && auth()->user()->isAdmin())
+                        <th class="py-3 px-3 first:pl-0 last:pr-0 text-left text-sm font-medium text-zinc-800 dark:text-white"
+                            data-flux-column="">
+                            <div class="whitespace-nowrap flex group-[]/right-align:justify-end">Owner</div>
+                        </th>
+                    @endif
                     <th class="py-3 px-3 first:pl-0 last:pr-0 text-left text-sm font-medium text-zinc-800 dark:text-white"
                         data-flux-column="">
                         <div class="whitespace-nowrap flex group-[]/right-align:justify-end">Friendly ID</div>
@@ -273,6 +295,23 @@ new class extends Component
                                 <flux:badge color="zinc" size="sm" class="ml-1">Shared</flux:badge>
                             @endif
                         </td>
+                        @if (config('app.multi_user_mode') && auth()->user()->isAdmin())
+                            <td class="py-3 px-3 first:pl-0 last:pr-0 text-sm whitespace-nowrap text-zinc-500 dark:text-zinc-300">
+                                <flux:select
+                                    wire:change="reassignDevice({{ $device->id }}, $event.target.value ? Number($event.target.value) : null)"
+                                    class="text-xs"
+                                >
+                                    <flux:select.option value="" :selected="$device->user_id === null">
+                                        {{ $device->user_id === null ? 'Assign owner...' : '— Unowned —' }}
+                                    </flux:select.option>
+                                    @foreach ($this->availableUsers as $u)
+                                        <flux:select.option value="{{ $u->id }}" :selected="$device->user_id === $u->id">
+                                            {{ $u->name }}
+                                        </flux:select.option>
+                                    @endforeach
+                                </flux:select>
+                            </td>
+                        @endif
                         <td class="py-3 px-3 first:pl-0 last:pr-0 text-sm whitespace-nowrap  text-zinc-500 dark:text-zinc-300"
                         >
                             {{ $device->friendly_id }}

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -152,7 +152,7 @@ new class extends Component
                     <flux:button icon="plus" variant="primary">Add Device</flux:button>
                 </flux:modal.trigger>
             </div>
-            @if (auth()->user()->isAdmin())
+            @if (config('app.multi_user_mode') && auth()->user()->isAdmin())
                 <div class="mb-4 flex items-center gap-2">
                     <flux:switch wire:model.live="showAllDevices" />
                     <span class="text-sm font-medium dark:text-zinc-200">Show all users' devices</span>

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -6,7 +6,11 @@ use Livewire\Component;
 
 new class extends Component
 {
+    use \Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
     public $devices;
+
+    public bool $showAllDevices = false;
 
     public $showDeviceForm = false;
 
@@ -40,7 +44,7 @@ new class extends Component
 
     public function mount()
     {
-        $this->devices = auth()->user()->devices;
+        $this->loadDevices();
         $this->deviceModels = DeviceModel::orderBy('label')->get()->sortBy(function ($deviceModel) {
             // Put TRMNL models at the top, then sort alphabetically within each group
             $isTrmnl = str_starts_with($deviceModel->label, 'TRMNL');
@@ -49,6 +53,40 @@ new class extends Component
         });
 
         return view('livewire.devices.manage');
+    }
+
+    public function loadDevices(): void
+    {
+        $user = auth()->user();
+
+        if ($user->isAdmin() && $this->showAllDevices) {
+            $this->devices = Device::all();
+        } else {
+            $this->devices = Device::where('user_id', $user->id)
+                ->orWhereNull('user_id')
+                ->get();
+        }
+    }
+
+    public function updatedShowAllDevices(): void
+    {
+        $this->loadDevices();
+    }
+
+    public function reassignDevice(int $deviceId, ?int $newOwnerId): void
+    {
+        $device = Device::findOrFail($deviceId);
+        $this->authorize('reassign', $device);
+
+        $device->update(['user_id' => $newOwnerId]);
+        $this->loadDevices();
+
+        Flux::toast(variant: 'success', text: 'Device ownership updated.');
+    }
+
+    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
+    {
+        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
     }
 
     public function updatedDeviceModelId(): void
@@ -87,7 +125,7 @@ new class extends Component
         $this->reset();
         Flux::modal('create-device')->close();
 
-        $this->devices = auth()->user()->devices;
+        $this->loadDevices();
         Flux::toast(variant: 'success', text: 'Device created successfully.');
     }
 
@@ -113,7 +151,7 @@ new class extends Component
         $device->update(['pause_until' => $pauseUntil]);
         $this->reset('pause_duration');
         Flux::modal('pause-device-'.$deviceId)->close();
-        $this->devices = auth()->user()->devices;
+        $this->loadDevices();
         Flux::toast(variant: 'success', text: 'Device paused until '.$pauseUntil->format('H:i'));
     }
 }
@@ -130,6 +168,11 @@ new class extends Component
                     <flux:button icon="plus" variant="primary">Add Device</flux:button>
                 </flux:modal.trigger>
             </div>
+            @if (auth()->user()->isAdmin())
+                <div class="mb-4">
+                    <flux:switch wire:model.live="showAllDevices" label="Show all users' devices"/>
+                </div>
+            @endif
             <flux:modal name="create-device" class="md:w-96">
                 <div class="space-y-6">
                     <div>
@@ -241,6 +284,9 @@ new class extends Component
                         <td class="py-3 px-3 first:pl-0 last:pr-0 text-sm whitespace-nowrap  text-zinc-500 dark:text-zinc-300"
                         >
                             {{ $device->name }}
+                            @if ($device->user_id === null)
+                                <flux:badge color="zinc" size="sm" class="ml-1">Shared</flux:badge>
+                            @endif
                         </td>
                         <td class="py-3 px-3 first:pl-0 last:pr-0 text-sm whitespace-nowrap  text-zinc-500 dark:text-zinc-300"
                         >
@@ -284,6 +330,17 @@ new class extends Component
                                                  :disabled="$device->mirror_device_id !== null"
                                                  label="☁️ Proxy"/>
                                 </flux:tooltip>
+                                @if (auth()->user()->isAdmin())
+                                    <flux:select wire:change="reassignDevice({{ $device->id }}, $event.target.value ? Number($event.target.value) : null)"
+                                                 class="text-xs">
+                                        <flux:select.option value="">Nobody</flux:select.option>
+                                        @foreach ($this->availableUsers as $u)
+                                            <flux:select.option value="{{ $u->id }}" :selected="$device->user_id === $u->id">
+                                                {{ $u->name }}
+                                            </flux:select.option>
+                                        @endforeach
+                                    </flux:select>
+                                @endif
                             </div>
                         </td>
                     </tr>

--- a/resources/views/livewire/playlists/index.blade.php
+++ b/resources/views/livewire/playlists/index.blade.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Models\Device;
 use App\Models\Playlist;
 use App\Models\PlaylistItem;
 use Livewire\Component;
@@ -9,6 +10,8 @@ new class extends Component
     public $devices;
 
     public $playlists;
+
+    public bool $showAllPlaylists = false;
 
     // Playlist form properties
     public $playlist_name;
@@ -23,22 +26,45 @@ new class extends Component
 
     public function mount()
     {
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
 
         return view('livewire.playlists.index');
     }
 
+    public function loadDevices(): void
+    {
+        $user = auth()->user();
+
+        if ($user->isAdmin() && $this->showAllPlaylists) {
+            $this->devices = Device::with(['playlists.items.plugin', 'user'])->get();
+        } else {
+            $this->devices = $user->devices()->with(['playlists.items.plugin'])->get();
+        }
+    }
+
+    public function updatedShowAllPlaylists(): void
+    {
+        $this->loadDevices();
+    }
+
+    protected function canManageDevice(Device $device): bool
+    {
+        $user = auth()->user();
+
+        return $user->isAdmin() || $user->devices->contains($device);
+    }
+
     public function togglePlaylistActive(Playlist $playlist)
     {
-        abort_unless(auth()->user()->devices->contains($playlist->device), 403);
+        abort_unless($this->canManageDevice($playlist->device), 403);
         $playlist->update(['is_active' => ! $playlist->is_active]);
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
     }
 
     public function sortPlaylistItem(int $id, int $position): void
     {
         $item = PlaylistItem::query()->with('playlist.device')->findOrFail($id);
-        abort_unless(auth()->user()->devices->contains($item->playlist->device), 403);
+        abort_unless($this->canManageDevice($item->playlist->device), 403);
 
         $items = $item->playlist->items()->orderBy('order')->orderBy('id')->get();
         $ids = $items->pluck('id')->all();
@@ -55,29 +81,29 @@ new class extends Component
             PlaylistItem::query()->whereKey($itemId)->update(['order' => $index]);
         }
 
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
     }
 
     public function togglePlaylistItemActive(PlaylistItem $item)
     {
-        abort_unless(auth()->user()->devices->contains($item->playlist->device), 403);
+        abort_unless($this->canManageDevice($item->playlist->device), 403);
         $item->update(['is_active' => ! $item->is_active]);
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
     }
 
     public function deletePlaylist(Playlist $playlist)
     {
-        abort_unless(auth()->user()->devices->contains($playlist->device), 403);
+        abort_unless($this->canManageDevice($playlist->device), 403);
         $playlist->delete();
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
         Flux::modal('delete-playlist-'.$playlist->id)->close();
     }
 
     public function deletePlaylistItem(PlaylistItem $item)
     {
-        abort_unless(auth()->user()->devices->contains($item->playlist->device), 403);
+        abort_unless($this->canManageDevice($item->playlist->device), 403);
         $item->delete();
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
         Flux::modal('delete-playlist-item-'.$item->id)->close();
     }
 
@@ -85,7 +111,7 @@ new class extends Component
     {
         $item->loadMissing(['playlist.device', 'plugin']);
 
-        abort_unless(auth()->user()->devices->contains($item->playlist->device), 403);
+        abort_unless($this->canManageDevice($item->playlist->device), 403);
 
         if ($item->isMashup()) {
             return;
@@ -95,18 +121,19 @@ new class extends Component
             return;
         }
 
-        abort_unless($item->plugin->user_id === auth()->id(), 403);
+        $user = auth()->user();
+        abort_unless($user->isAdmin() || $item->plugin->user_id === $user->id, 403);
 
         $item->plugin->clearCurrentImage();
 
         Flux::toast(variant: 'success', text: 'Image cache cleared.');
 
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
     }
 
     public function editPlaylist(Playlist $playlist)
     {
-        abort_unless(auth()->user()->devices->contains($playlist->device), 403);
+        abort_unless($this->canManageDevice($playlist->device), 403);
 
         $this->validate([
             'playlist_name' => 'required|string|max:255',
@@ -138,7 +165,7 @@ new class extends Component
             'refresh_time' => $this->refresh_time,
         ]);
 
-        $this->devices = auth()->user()->devices()->with(['playlists.items.plugin'])->get();
+        $this->loadDevices();
         $this->reset(['playlist_name', 'selected_weekdays', 'active_from', 'active_until', 'refresh_time']);
         Flux::modal('edit-playlist-'.$playlist->id)->close();
     }
@@ -160,11 +187,27 @@ new class extends Component
                 <h2 class="text-2xl font-semibold dark:text-gray-100">Playlists</h2>
             </div>
 
+            @if (config('app.multi_user_mode') && auth()->user()->isAdmin())
+                <div class="mb-4 flex items-center gap-2">
+                    <flux:switch wire:model.live="showAllPlaylists" />
+                    <span class="text-sm font-medium dark:text-zinc-200">Show all users' playlists</span>
+                </div>
+            @endif
+
             @foreach($devices as $device)
                 @if($device->playlists->isNotEmpty())
                     <div class="mb-8">
                         <div class="flex items-center justify-between mb-4">
-                            <h3 class="text-lg font-medium dark:text-zinc-200">{{ $device->name }}</h3>
+                            <h3 class="text-lg font-medium dark:text-zinc-200">
+                                {{ $device->name }}
+                                @if (config('app.multi_user_mode') && auth()->user()->isAdmin() && $showAllPlaylists)
+                                    @if ($device->user_id === null)
+                                        <flux:badge color="zinc" size="sm" class="ml-1">Shared</flux:badge>
+                                    @elseif ($device->user_id !== auth()->id())
+                                        <flux:badge color="zinc" size="sm" class="ml-1">{{ $device->user?->name ?? 'User #'.$device->user_id }}</flux:badge>
+                                    @endif
+                                @endif
+                            </h3>
                             <flux:button href="{{ route('devices.configure', $device) }}" wire:navigate icon="eye">
                             </flux:button>
                         </div>

--- a/resources/views/livewire/playlists/index.blade.php
+++ b/resources/views/livewire/playlists/index.blade.php
@@ -38,7 +38,11 @@ new class extends Component
         if ($user->isAdmin() && $this->showAllPlaylists) {
             $this->devices = Device::with(['playlists.items.plugin', 'user'])->get();
         } else {
-            $this->devices = $user->devices()->with(['playlists.items.plugin'])->get();
+            $this->devices = Device::with(['playlists.items.plugin'])
+                ->where(function ($q) use ($user) {
+                    $q->where('user_id', $user->id)->orWhereNull('user_id');
+                })
+                ->get();
         }
     }
 
@@ -51,7 +55,9 @@ new class extends Component
     {
         $user = auth()->user();
 
-        return $user->isAdmin() || $user->devices->contains($device);
+        return $user->isAdmin()
+            || $device->user_id === null
+            || $device->user_id === $user->id;
     }
 
     public function togglePlaylistActive(Playlist $playlist)

--- a/resources/views/livewire/plugins/index.blade.php
+++ b/resources/views/livewire/plugins/index.blade.php
@@ -540,7 +540,7 @@ new class extends Component
                     x-data="{ pluginName: {{ json_encode(strtolower($plugin['name'] ?? '')) }} }"
                     x-show="searchTerm.length <= 1 || pluginName.includes(searchTerm.toLowerCase())"
                     class="styled-container flex flex-col">
-                    @php $isOtherUsersShared = ($plugin['is_shared'] ?? false) && ($plugin['user_id'] ?? null) !== auth()->id(); @endphp
+                    @php $isOtherUsersShared = $activeTab === 'shared' && ($plugin['is_shared'] ?? false) && ($plugin['user_id'] ?? null) !== auth()->id(); @endphp
                     @if ($isOtherUsersShared)
                         <div class="block flex-1">
                     @else

--- a/resources/views/livewire/plugins/index.blade.php
+++ b/resources/views/livewire/plugins/index.blade.php
@@ -525,24 +525,11 @@ new class extends Component
                         </a>
                     @endif
 
-                    @if (isset($plugin['id']))
-                        <div class="px-4 pb-4 flex flex-wrap items-center gap-2">
-                            @if (config('app.multi_user_mode'))
-                                {{-- Share toggle (owner or admin only) --}}
-                                @if (($plugin['user_id'] ?? null) === auth()->id() || auth()->user()->isAdmin())
-                                    <flux:switch wire:click="toggleShared({{ $plugin['id'] }})"
-                                                 :checked="$plugin['is_shared'] ?? false"
-                                                 label="Shared"/>
-                                @endif
-
-                                {{-- Copy button: visible to non-owners when plugin is shared --}}
-                                @if (($plugin['is_shared'] ?? false) && ($plugin['user_id'] ?? null) !== auth()->id())
-                                    <flux:button size="sm" wire:click="copyPlugin({{ $plugin['id'] }})">
-                                        Install Copy
-                                    </flux:button>
-                                @endif
-                            @endif
-
+                    @if (isset($plugin['id']) && $isOtherUsersShared)
+                        <div class="px-4 pb-4">
+                            <flux:button size="sm" wire:click="copyPlugin({{ $plugin['id'] }})">
+                                Install Copy
+                            </flux:button>
                         </div>
                     @endif
                 </div>

--- a/resources/views/livewire/plugins/index.blade.php
+++ b/resources/views/livewire/plugins/index.blade.php
@@ -297,13 +297,15 @@ new class extends Component
                          wire:click="$set('activeTab', 'mine')">
                 My Plugins
             </flux:button>
-            <flux:button variant="{{ $activeTab === 'shared' ? 'primary' : 'ghost' }}"
-                         wire:click="$set('activeTab', 'shared')">
-                Shared Plugins
-            </flux:button>
+            @if (config('app.multi_user_mode'))
+                <flux:button variant="{{ $activeTab === 'shared' ? 'primary' : 'ghost' }}"
+                             wire:click="$set('activeTab', 'shared')">
+                    Shared Plugins
+                </flux:button>
+            @endif
         </div>
 
-        @if (auth()->user()->isAdmin() && $activeTab === 'mine')
+        @if (config('app.multi_user_mode') && auth()->user()->isAdmin() && $activeTab === 'mine')
             <div class="mb-4 flex items-center gap-2">
                 <flux:switch wire:model.live="showAllPlugins" />
                 <span class="text-sm font-medium dark:text-zinc-200">Show all users' plugins</span>
@@ -525,18 +527,20 @@ new class extends Component
 
                     @if (isset($plugin['id']))
                         <div class="px-4 pb-4 flex flex-wrap items-center gap-2">
-                            {{-- Share toggle (owner or admin only) --}}
-                            @if (($plugin['user_id'] ?? null) === auth()->id() || auth()->user()->isAdmin())
-                                <flux:switch wire:click="toggleShared({{ $plugin['id'] }})"
-                                             :checked="$plugin['is_shared'] ?? false"
-                                             label="Shared"/>
-                            @endif
+                            @if (config('app.multi_user_mode'))
+                                {{-- Share toggle (owner or admin only) --}}
+                                @if (($plugin['user_id'] ?? null) === auth()->id() || auth()->user()->isAdmin())
+                                    <flux:switch wire:click="toggleShared({{ $plugin['id'] }})"
+                                                 :checked="$plugin['is_shared'] ?? false"
+                                                 label="Shared"/>
+                                @endif
 
-                            {{-- Copy button: visible to non-owners when plugin is shared --}}
-                            @if (($plugin['is_shared'] ?? false) && ($plugin['user_id'] ?? null) !== auth()->id())
-                                <flux:button size="sm" wire:click="copyPlugin({{ $plugin['id'] }})">
-                                    Install Copy
-                                </flux:button>
+                                {{-- Copy button: visible to non-owners when plugin is shared --}}
+                                @if (($plugin['is_shared'] ?? false) && ($plugin['user_id'] ?? null) !== auth()->id())
+                                    <flux:button size="sm" wire:click="copyPlugin({{ $plugin['id'] }})">
+                                        Install Copy
+                                    </flux:button>
+                                @endif
                             @endif
 
                         </div>

--- a/resources/views/livewire/plugins/index.blade.php
+++ b/resources/views/livewire/plugins/index.blade.php
@@ -1,11 +1,14 @@
 <?php
 
 use App\Console\Commands\ExampleRecipesSeederCommand;
+use App\Models\Device;
+use App\Models\DeviceModel;
 use App\Models\Plugin;
 use App\Models\User;
 use App\Plugins\PluginRegistry;
 use App\Services\PluginImportService;
 use Illuminate\Support\Str;
+use Keepsuit\Liquid\Exceptions\LiquidException;
 use Livewire\Component;
 use Livewire\WithFileUploads;
 
@@ -190,6 +193,40 @@ new class extends Component
 
         $this->refreshPlugins();
         Flux::toast(variant: 'success', text: "'{$plugin->name}' copied to your plugins.");
+    }
+
+    public ?int $preview_plugin_id = null;
+
+    public ?string $preview_plugin_name = null;
+
+    public function previewPlugin(int $pluginId): void
+    {
+        $plugin = Plugin::findOrFail($pluginId);
+        $this->authorize('copy', $plugin);
+
+        $this->preview_plugin_id = $plugin->id;
+        $this->preview_plugin_name = $plugin->name;
+
+        try {
+            $device = new Device();
+            $deviceModel = DeviceModel::with(['palette'])->first();
+            $device->setRelation('deviceModel', $deviceModel);
+            $previewMarkup = $plugin->render('full', true, $device);
+            $width = (int) ($deviceModel?->width ?? 800);
+            $height = (int) ($deviceModel?->height ?? 480);
+            $this->dispatch(
+                'shared-preview-updated',
+                preview: $previewMarkup,
+                screenWidth: $width,
+                screenHeight: $height,
+            );
+        } catch (LiquidException $e) {
+            $this->dispatch('shared-preview-error', message: $e->toLiquidErrorMessage());
+        } catch (Exception $e) {
+            $this->dispatch('shared-preview-error', message: $e->getMessage());
+        }
+
+        Flux::modal('preview-shared-plugin')->show();
     }
 
     public function getListeners(): array
@@ -526,7 +563,10 @@ new class extends Component
                     @endif
 
                     @if (isset($plugin['id']) && $isOtherUsersShared)
-                        <div class="px-4 pb-4">
+                        <div class="px-4 pb-4 flex gap-2">
+                            <flux:button size="sm" icon="eye" wire:click="previewPlugin({{ $plugin['id'] }})">
+                                Preview
+                            </flux:button>
                             <flux:button size="sm" wire:click="copyPlugin({{ $plugin['id'] }})">
                                 Install Copy
                             </flux:button>
@@ -536,4 +576,74 @@ new class extends Component
             @endforeach
         </div>
     </div>
+
+    <flux:modal name="preview-shared-plugin" class="min-w-[850px] max-h-[90vh]">
+        <div class="flex min-h-0 max-h-[90vh] flex-col gap-4">
+            <flux:heading size="lg">Preview {{ $preview_plugin_name }}</flux:heading>
+            <div
+                id="shared-preview-stage"
+                class="flex w-full flex-1 min-h-[50vh] items-center justify-center overflow-hidden rounded-lg bg-white dark:bg-zinc-900"
+            >
+                <div id="shared-preview-layout" class="overflow-hidden">
+                    <div id="shared-preview-scaler" class="origin-top-left">
+                        <iframe id="shared-preview-frame" class="block border-0"></iframe>
+                    </div>
+                </div>
+            </div>
+            <p id="shared-preview-error" class="text-sm text-red-600 dark:text-red-400" x-cloak style="display:none"></p>
+        </div>
+    </flux:modal>
+
+    @script
+    <script>
+        let sharedPreviewNativeWidth = 800;
+        let sharedPreviewNativeHeight = 480;
+
+        function fitSharedPreview() {
+            const stage = document.getElementById('shared-preview-stage');
+            const layout = document.getElementById('shared-preview-layout');
+            const scaler = document.getElementById('shared-preview-scaler');
+            const frame = document.getElementById('shared-preview-frame');
+            if (!stage || !layout || !scaler || !frame) return;
+
+            const w = sharedPreviewNativeWidth;
+            const h = sharedPreviewNativeHeight;
+            if (w <= 0 || h <= 0) return;
+
+            const stageW = stage.clientWidth;
+            const stageH = stage.clientHeight;
+            if (stageW <= 0 || stageH <= 0) return;
+
+            const scale = Math.min(1, stageW / w, stageH / h);
+            layout.style.width = `${w * scale}px`;
+            layout.style.height = `${h * scale}px`;
+            scaler.style.width = `${w}px`;
+            scaler.style.height = `${h}px`;
+            scaler.style.transform = `scale(${scale})`;
+            frame.style.width = `${w}px`;
+            frame.style.height = `${h}px`;
+        }
+
+        $wire.on('shared-preview-updated', ({ preview, screenWidth, screenHeight }) => {
+            sharedPreviewNativeWidth = Number(screenWidth) || 800;
+            sharedPreviewNativeHeight = Number(screenHeight) || 480;
+            const errEl = document.getElementById('shared-preview-error');
+            if (errEl) { errEl.style.display = 'none'; errEl.textContent = ''; }
+            const frame = document.getElementById('shared-preview-frame');
+            if (frame) {
+                frame.srcdoc = preview;
+            }
+            setTimeout(fitSharedPreview, 50);
+        });
+
+        $wire.on('shared-preview-error', ({ message }) => {
+            const errEl = document.getElementById('shared-preview-error');
+            if (errEl) { errEl.style.display = 'block'; errEl.textContent = message; }
+            const frame = document.getElementById('shared-preview-frame');
+            if (frame) frame.srcdoc = '';
+        });
+
+        window.addEventListener('resize', fitSharedPreview);
+    </script>
+    @endscript
 </div>

--- a/resources/views/livewire/plugins/index.blade.php
+++ b/resources/views/livewire/plugins/index.blade.php
@@ -1,6 +1,8 @@
 <?php
 
 use App\Console\Commands\ExampleRecipesSeederCommand;
+use App\Models\Plugin;
+use App\Models\User;
 use App\Plugins\PluginRegistry;
 use App\Services\PluginImportService;
 use Illuminate\Support\Str;
@@ -10,6 +12,7 @@ use Livewire\WithFileUploads;
 new class extends Component
 {
     use WithFileUploads;
+    use \Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
     public string $name;
 
@@ -30,6 +33,10 @@ new class extends Component
     public $zipFile;
 
     public string $sortBy = 'date_asc';
+
+    public bool $showAllPlugins = false;
+
+    public string $activeTab = 'mine'; // 'mine' | 'shared'
 
     public array $native_plugins = [];
 
@@ -68,16 +75,35 @@ new class extends Component
 
     public function refreshPlugins(): void
     {
-        // Only show recipe plugins in the main list (image_webhook has its own management page)
-        $userPlugins = auth()->user()?->plugins()
-            ->where('plugin_type', 'recipe')
-            ->get()
-            ->makeHidden(['render_markup', 'data_payload'])
-            ->toArray();
-        $allPlugins = array_merge($this->nativePlugins(), $userPlugins ?? []);
-        $allPlugins = array_values($allPlugins);
-        $allPlugins = $this->sortPlugins($allPlugins);
-        $this->plugins = $allPlugins;
+        $user = auth()->user();
+
+        if ($this->activeTab === 'shared') {
+            $userPlugins = Plugin::where('is_shared', true)
+                ->where('plugin_type', 'recipe')
+                ->with('user')
+                ->get()
+                ->makeHidden(['render_markup', 'data_payload'])
+                ->toArray();
+        } elseif ($user->isAdmin() && $this->showAllPlugins) {
+            $userPlugins = Plugin::where('plugin_type', 'recipe')
+                ->with('user')
+                ->get()
+                ->makeHidden(['render_markup', 'data_payload'])
+                ->toArray();
+        } else {
+            // Only show recipe plugins in the main list (image_webhook has its own management page)
+            $userPlugins = $user->plugins()
+                ->where('plugin_type', 'recipe')
+                ->get()
+                ->makeHidden(['render_markup', 'data_payload'])
+                ->toArray();
+        }
+
+        $allPlugins = $this->activeTab === 'mine'
+            ? array_merge($this->nativePlugins(), $userPlugins ?? [])
+            : $userPlugins ?? [];
+
+        $this->plugins = $this->sortPlugins(array_values($allPlugins));
     }
 
     protected function sortPlugins(array $plugins): array
@@ -127,6 +153,43 @@ new class extends Component
     public function updatedSortBy(): void
     {
         $this->refreshPlugins();
+    }
+
+    public function updatedActiveTab(): void
+    {
+        $this->refreshPlugins();
+    }
+
+    public function updatedShowAllPlugins(): void
+    {
+        $this->refreshPlugins();
+    }
+
+    public function toggleShared(int $pluginId): void
+    {
+        $plugin = Plugin::findOrFail($pluginId);
+        $this->authorize('share', $plugin);
+
+        $plugin->update(['is_shared' => ! $plugin->is_shared]);
+        $this->refreshPlugins();
+
+        Flux::toast(variant: 'success', text: $plugin->fresh()->is_shared ? 'Plugin shared.' : 'Plugin unshared.');
+    }
+
+    public function copyPlugin(int $pluginId): void
+    {
+        $plugin = Plugin::findOrFail($pluginId);
+        $this->authorize('copy', $plugin);
+
+        $copy = $plugin->replicate(['id', 'uuid', 'trmnlp_id']);
+        $copy->user_id = auth()->id();
+        $copy->is_shared = false;
+        $copy->trmnlp_id = (string) \Symfony\Component\Uid\Uuid::v7();
+        $copy->uuid = (string) \Symfony\Component\Uid\Uuid::v4();
+        $copy->save();
+
+        $this->refreshPlugins();
+        Flux::toast(variant: 'success', text: "'{$plugin->name}' copied to your plugins.");
     }
 
     public function getListeners(): array
@@ -228,6 +291,24 @@ new class extends Component
                 </flux:button.group>
             </div>
         </div>
+
+        <div class="flex gap-4 mb-4">
+            <flux:button variant="{{ $activeTab === 'mine' ? 'primary' : 'ghost' }}"
+                         wire:click="$set('activeTab', 'mine')">
+                My Plugins
+            </flux:button>
+            <flux:button variant="{{ $activeTab === 'shared' ? 'primary' : 'ghost' }}"
+                         wire:click="$set('activeTab', 'shared')">
+                Shared Plugins
+            </flux:button>
+        </div>
+
+        @if (auth()->user()->isAdmin() && $activeTab === 'mine')
+            <div class="mb-4 flex items-center gap-2">
+                <flux:switch wire:model.live="showAllPlugins" />
+                <span class="text-sm font-medium dark:text-zinc-200">Show all users' plugins</span>
+            </div>
+        @endif
 
         <div x-show="showFilters" class="mb-6 flex flex-col sm:flex-row gap-4" style="display: none;">
             <div class="flex-1">
@@ -419,10 +500,15 @@ new class extends Component
                     wire:key="plugin-{{ $plugin['id'] ?? $plugin['name'] ?? $index }}"
                     x-data="{ pluginName: {{ json_encode(strtolower($plugin['name'] ?? '')) }} }"
                     x-show="searchTerm.length <= 1 || pluginName.includes(searchTerm.toLowerCase())"
-                    class="styled-container">
-                    <a href="{{ $plugin['detail_view_url'] ?? route('plugins.recipe', ['plugin' => $plugin['id']]) }}"
-                       class="block h-full">
-                        <div class="flex items-center space-x-4 px-10 py-8 h-full">
+                    class="styled-container flex flex-col">
+                    @php $isOtherUsersShared = ($plugin['is_shared'] ?? false) && ($plugin['user_id'] ?? null) !== auth()->id(); @endphp
+                    @if ($isOtherUsersShared)
+                        <div class="block flex-1">
+                    @else
+                        <a href="{{ $plugin['detail_view_url'] ?? route('plugins.recipe', ['plugin' => $plugin['id']]) }}"
+                           class="block flex-1">
+                    @endif
+                        <div class="flex items-center space-x-4 px-10 py-8">
                             @isset($plugin['icon_url'])
                                 <img src="{{ $plugin['icon_url'] }}" class="h-6"/>
                             @else
@@ -431,7 +517,30 @@ new class extends Component
                             @endif
                             <h3 class="text-lg font-medium dark:text-zinc-200">{{$plugin['name']}}</h3>
                         </div>
-                    </a>
+                    @if ($isOtherUsersShared)
+                        </div>
+                    @else
+                        </a>
+                    @endif
+
+                    @if (isset($plugin['id']))
+                        <div class="px-4 pb-4 flex flex-wrap items-center gap-2">
+                            {{-- Share toggle (owner or admin only) --}}
+                            @if (($plugin['user_id'] ?? null) === auth()->id() || auth()->user()->isAdmin())
+                                <flux:switch wire:click="toggleShared({{ $plugin['id'] }})"
+                                             :checked="$plugin['is_shared'] ?? false"
+                                             label="Shared"/>
+                            @endif
+
+                            {{-- Copy button: visible to non-owners when plugin is shared --}}
+                            @if (($plugin['is_shared'] ?? false) && ($plugin['user_id'] ?? null) !== auth()->id())
+                                <flux:button size="sm" wire:click="copyPlugin({{ $plugin['id'] }})">
+                                    Install Copy
+                                </flux:button>
+                            @endif
+
+                        </div>
+                    @endif
                 </div>
             @endforeach
         </div>

--- a/resources/views/livewire/plugins/markup.blade.php
+++ b/resources/views/livewire/plugins/markup.blade.php
@@ -31,7 +31,7 @@ new class extends Component
         // only devices that are owned by the user
         $this->checked_devices = array_intersect($this->checked_devices, auth()->user()->devices->pluck('id')->toArray());
 
-        $isAdminOrAllowed = auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
+        $isAdminOrAllowed = ! config('app.multi_user_mode') || auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
         abort_unless($isAdminOrAllowed, 403, 'Blade rendering is restricted to administrators.');
 
         try {

--- a/resources/views/livewire/plugins/markup.blade.php
+++ b/resources/views/livewire/plugins/markup.blade.php
@@ -31,6 +31,9 @@ new class extends Component
         // only devices that are owned by the user
         $this->checked_devices = array_intersect($this->checked_devices, auth()->user()->devices->pluck('id')->toArray());
 
+        $isAdminOrAllowed = auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
+        abort_unless($isAdminOrAllowed, 403, 'Blade rendering is restricted to administrators.');
+
         try {
             $rendered = Blade::render($this->blade_code);
             foreach ($this->checked_devices as $device) {

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -15,6 +15,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 new class extends Component
 {
+    use \Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
     public Plugin $plugin;
 
     public ?string $markup_code;
@@ -81,9 +83,27 @@ new class extends Component
 
     public ?string $transform_run_output = null;
 
+    public bool $is_shared = false;
+
+    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
+    {
+        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
+    }
+
+    public function reassignPlugin(int $newOwnerId): void
+    {
+        $this->authorize('reassign', $this->plugin);
+
+        $newOwner = \App\Models\User::findOrFail($newOwnerId);
+        $this->plugin->update(['user_id' => $newOwner->id]);
+        $this->plugin = $this->plugin->fresh();
+
+        Flux::toast(variant: 'success', text: 'Plugin ownership updated.');
+    }
+
     public function mount(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->blade_code = $this->plugin->render_markup;
         // required to render some stuff
         $this->configuration_template = $this->plugin->configuration_template ?? [];
@@ -157,6 +177,17 @@ new class extends Component
         $this->polling_header = $this->plugin->polling_header;
         $this->polling_body = $this->plugin->polling_body;
         $this->data_payload = json_encode($this->plugin->data_payload, JSON_PRETTY_PRINT);
+        $this->is_shared = (bool) $this->plugin->is_shared;
+    }
+
+    public function toggleShared(): void
+    {
+        $this->authorize('share', $this->plugin);
+
+        $this->plugin->update(['is_shared' => ! $this->plugin->is_shared]);
+        $this->is_shared = (bool) $this->plugin->fresh()->is_shared;
+
+        Flux::toast(variant: 'success', text: $this->is_shared ? 'Plugin shared.' : 'Plugin unshared.');
     }
 
     public function saveMarkup(): void
@@ -207,13 +238,22 @@ new class extends Component
 
     public function switchTab(string $layout): void
     {
-        if (in_array($layout, $this->active_tabs, true)) {
-            // Save current tab's content before switching
-            if (isset($this->markup_layouts[$this->active_tab])) {
-                $this->markup_layouts[$this->active_tab] = $this->markup_code ?? '';
-            }
+        $isMarkupTab = in_array($layout, $this->active_tabs, true);
+        $isTransformTab = $layout === 'transform'
+            && $this->transform_code !== null
+            && app(ServerlessTransformService::class)->isEnabled();
 
-            $this->active_tab = $layout;
+        if (! $isMarkupTab && ! $isTransformTab) {
+            return;
+        }
+
+        // Save outgoing markup tab content (not when leaving the transform tab)
+        if ($this->active_tab !== 'transform' && isset($this->markup_layouts[$this->active_tab])) {
+            $this->markup_layouts[$this->active_tab] = $this->markup_code ?? '';
+        }
+
+        $this->active_tab = $layout;
+        if ($layout !== 'transform') {
             $this->markup_code = $this->markup_layouts[$layout] ?? '';
         }
     }
@@ -249,6 +289,7 @@ new class extends Component
             'half_vertical' => 'Half Vertical',
             'quadrant' => 'Quadrant',
             'shared' => 'Shared',
+            'transform' => 'Transform',
             default => ucfirst($layout),
         };
     }
@@ -538,14 +579,6 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
-
-            if ($this->transform_run_output !== null) {
-                $decoded = json_decode($this->transform_run_output, true);
-                if (is_array($decoded)) {
-                    $this->plugin->data_payload = $decoded;
-                }
-            }
-
             $previewMarkup = $this->plugin->render($size, true, $device);
             $dimensions = $this->previewScreenDimensionsForDevice($device);
             $this->dispatch(
@@ -604,14 +637,6 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
-
-            if ($this->transform_run_output !== null) {
-                $decoded = json_decode($this->transform_run_output, true);
-                if (is_array($decoded)) {
-                    $this->plugin->data_payload = $decoded;
-                }
-            }
-
             $markup = $this->plugin->render($this->preview_size, true, $device);
 
             $imageUuid = App\Services\ImageGenerationService::generateImageFromModel(
@@ -717,21 +742,49 @@ HTML;
         $this->redirect(route('plugins.index'));
     }
 
-    public function addTransform(): void
+    public function enableTransform(): void
     {
-        $this->transform_code = '';
-        $this->transform_language = 'python';
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        if ($this->transform_code === null) {
+            $this->transform_code = '';
+            $this->transform_language ??= 'python';
+            $this->plugin->update([
+                'transform_code'     => '',
+                'transform_language' => $this->transform_language,
+            ]);
+        }
+    }
+
+    public function disableTransform(): void
+    {
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
+        $this->transform_code = null;
+        $this->transform_run_output = null;
+        $this->plugin->update(['transform_code' => null, 'transform_language' => null]);
+        if ($this->active_tab === 'transform') {
+            $this->active_tab = 'full';
+            $this->markup_code = $this->markup_layouts['full'] ?? '';
+        }
+    }
+
+    public function updatedTransformLanguage(): void
+    {
+        if ($this->transform_code !== null) {
+            $this->plugin->update(['transform_language' => $this->transform_language]);
+        }
     }
 
     public function saveTransform(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->validate(['transform_code' => 'nullable|string', 'transform_language' => 'nullable|string|in:python,node,php']);
 
         $this->plugin->update([
-            'transform_code'     => $this->transform_code ?: null,
-            'transform_language' => $this->transform_code ? $this->transform_language : null,
+            'transform_code'     => $this->transform_code,
+            'transform_language' => $this->transform_language,
         ]);
+
+        Flux::toast(variant: 'success', text: 'Transform saved.');
     }
 
     public function runTransform(): void
@@ -801,55 +854,62 @@ HTML;
     "
 >
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center mb-6">
+        <div class="flex justify-between items-center mb-3">
             <h2 class="text-2xl font-semibold dark:text-gray-100">{{$plugin->name}}
                 <flux:badge size="sm" class="ml-2">Recipe</flux:badge>
             </h2>
 
-            <flux:button.group>
-                <flux:modal.trigger name="preview-plugin">
-                    <flux:button icon="eye" wire:click="renderPreview" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Preview</flux:button>
-                </flux:modal.trigger>
-                <flux:dropdown>
-                    <flux:button icon="chevron-down" :disabled="$plugin->hasMissingRequiredConfigurationFields()"></flux:button>
-                    <flux:menu>
-                        <flux:modal.trigger name="preview-plugin">
-                            <flux:menu.item icon="mashup-1Tx1B" wire:click="renderPreview('half_horizontal')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Horizontal
-                            </flux:menu.item>
-                        </flux:modal.trigger>
+            <div class="flex items-center gap-3">
+                @if($plugin->user_id === auth()->id() || auth()->user()->isAdmin())
+                    <flux:switch wire:click="toggleShared" :checked="$is_shared" label="Shared"/>
+                @endif
 
-                        <flux:modal.trigger name="preview-plugin">
-                            <flux:menu.item icon="mashup-1Lx1R" wire:click="renderPreview('half_vertical')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Vertical
-                            </flux:menu.item>
-                        </flux:modal.trigger>
+                <flux:button.group>
+                    <flux:modal.trigger name="preview-plugin">
+                        <flux:button icon="eye" wire:click="renderPreview" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Preview</flux:button>
+                    </flux:modal.trigger>
+                    <flux:dropdown>
+                        <flux:button icon="chevron-down" :disabled="$plugin->hasMissingRequiredConfigurationFields()"></flux:button>
+                        <flux:menu>
+                            <flux:modal.trigger name="preview-plugin">
+                                <flux:menu.item icon="mashup-1Tx1B" wire:click="renderPreview('half_horizontal')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Horizontal
+                                </flux:menu.item>
+                            </flux:modal.trigger>
 
-                        <flux:modal.trigger name="preview-plugin">
-                            <flux:menu.item icon="mashup-2x2" wire:click="renderPreview('quadrant')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Quadrant</flux:menu.item>
-                        </flux:modal.trigger>
-                    </flux:menu>
-                </flux:dropdown>
-            </flux:button.group>
-            <flux:button.group>
-                <flux:modal.trigger name="add-to-playlist">
-                    <flux:button icon="play" variant="primary" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Add to Playlist</flux:button>
-                </flux:modal.trigger>
+                            <flux:modal.trigger name="preview-plugin">
+                                <flux:menu.item icon="mashup-1Lx1R" wire:click="renderPreview('half_vertical')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Half-Vertical
+                                </flux:menu.item>
+                            </flux:modal.trigger>
 
-                <flux:dropdown>
-                    <flux:button icon="chevron-down" variant="primary"></flux:button>
-                    <flux:menu>
-                        <flux:modal.trigger name="trmnlp-settings">
-                            <flux:menu.item icon="cog">Recipe Settings</flux:menu.item>
-                        </flux:modal.trigger>
-                        <flux:menu.separator />
-                        <flux:menu.item icon="document-duplicate" wire:click="duplicatePlugin">Duplicate Plugin</flux:menu.item>
-                        <flux:modal.trigger name="delete-plugin">
-                            <flux:menu.item icon="trash" variant="danger">Delete Plugin</flux:menu.item>
-                        </flux:modal.trigger>
-                        <flux:menu.separator />
-                        <flux:menu.item icon="archive-box" wire:click="exportPluginArchive">Export Recipe Archive</flux:menu.item>
-                    </flux:menu>
-                </flux:dropdown>
-            </flux:button.group>
+                            <flux:modal.trigger name="preview-plugin">
+                                <flux:menu.item icon="mashup-2x2" wire:click="renderPreview('quadrant')" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Quadrant</flux:menu.item>
+                            </flux:modal.trigger>
+                        </flux:menu>
+                    </flux:dropdown>
+                </flux:button.group>
+
+                <flux:button.group>
+                    <flux:modal.trigger name="add-to-playlist">
+                        <flux:button icon="play" variant="primary" :disabled="$plugin->hasMissingRequiredConfigurationFields()">Add to Playlist</flux:button>
+                    </flux:modal.trigger>
+
+                    <flux:dropdown>
+                        <flux:button icon="chevron-down" variant="primary"></flux:button>
+                        <flux:menu>
+                            <flux:modal.trigger name="trmnlp-settings">
+                                <flux:menu.item icon="cog">Recipe Settings</flux:menu.item>
+                            </flux:modal.trigger>
+                            <flux:menu.separator />
+                            <flux:menu.item icon="document-duplicate" wire:click="duplicatePlugin">Duplicate Plugin</flux:menu.item>
+                            <flux:modal.trigger name="delete-plugin">
+                                <flux:menu.item icon="trash" variant="danger">Delete Plugin</flux:menu.item>
+                            </flux:modal.trigger>
+                            <flux:menu.separator />
+                            <flux:menu.item icon="archive-box" wire:click="exportPluginArchive">Export Recipe Archive</flux:menu.item>
+                        </flux:menu>
+                    </flux:dropdown>
+                </flux:button.group>
+            </div>
         </div>
 
         <flux:modal name="add-to-playlist" class="min-w-2xl">
@@ -1071,6 +1131,18 @@ HTML;
                                     name="name" autofocus/>
                     </div>
 
+                    @if(auth()->user()->isAdmin())
+                        <div class="mb-4">
+                            <flux:select label="Owner" wire:change="reassignPlugin($event.target.value)">
+                                @foreach ($this->availableUsers as $u)
+                                    <flux:select.option value="{{ $u->id }}" :selected="$plugin->user_id === $u->id">
+                                        {{ $u->name }}
+                                    </flux:select.option>
+                                @endforeach
+                            </flux:select>
+                        </div>
+                    @endif
+
                     @php
                         $authorField = null;
                         if (isset($configuration_template['custom_fields'])) {
@@ -1161,8 +1233,17 @@ HTML;
                     @if($data_strategy === 'polling')
                     <flux:label>Polling URL</flux:label>
 
-                    <div x-data="{ subTab: 'settings' }" class="mt-2 mb-4">
+                    <div x-data="{ subTab: 'urls' }" class="mt-2 mb-4">
                         <div class="flex">
+                            <button
+                                @click="subTab = 'urls'"
+                                class="tab-button"
+                                :class="subTab === 'urls' ? 'is-active' : ''"
+                            >
+                                <flux:icon.link class="size-4"/>
+                                URLs
+                            </button>
+
                             <button
                                 @click="subTab = 'settings'"
                                 class="tab-button"
@@ -1172,18 +1253,21 @@ HTML;
                                 Settings
                             </button>
 
+                            @if(app(ServerlessTransformService::class)->isEnabled())
                             <button
-                                @click="subTab = 'preview'"
+                                @click="subTab = 'transform'"
                                 class="tab-button"
-                                :class="subTab === 'preview' ? 'is-active' : ''"
+                                :class="subTab === 'transform' ? 'is-active' : ''"
                             >
-                                <flux:icon.eye class="size-4" />
-                                Preview URL
+                                <flux:icon.code-bracket class="size-4"/>
+                                Transform
                             </button>
+                            @endif
                         </div>
 
                         <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
-                            <div x-show="subTab === 'settings'">
+                            {{-- URLs tab --}}
+                            <div x-show="subTab === 'urls'">
                                 <flux:field>
                                     <flux:description>Enter the URL(s) to poll for data:</flux:description>
                                     <flux:textarea
@@ -1195,63 +1279,91 @@ HTML;
                                         {!! 'Hint: Supports multiple requests via line break separation. You can also use configuration variables with <a href="https://help.usetrmnl.com/en/articles/12689499-dynamic-polling-urls">Liquid syntax</a>. ' !!}
                                     </flux:description>
                                 </flux:field>
+
+                                <div class="mt-3">
+                                    <flux:field>
+                                        <flux:description>Preview computed URLs here (readonly):</flux:description>
+                                        <flux:textarea
+                                            readonly
+                                            placeholder="Nothing to show..."
+                                            rows="3"
+                                        >
+                                            {{ $this->parsed_urls }}
+                                        </flux:textarea>
+                                    </flux:field>
+                                </div>
+
+                                <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
+                                    Fetch data now
+                                </flux:button>
                             </div>
 
-                            <div x-show="subTab === 'preview'" x-cloak>
-                                <flux:field>
-                                    <flux:description>Preview computed URLs here (readonly):</flux:description>
+                            {{-- Settings tab --}}
+                            <div x-show="subTab === 'settings'" x-cloak>
+                                <div class="mb-4">
+                                    <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
+                                        <flux:radio value="get" label="GET"/>
+                                        <flux:radio value="post" label="POST"/>
+                                    </flux:radio.group>
+                                </div>
+
+                                <div class="mb-4">
                                     <flux:textarea
-                                        readonly
-                                        placeholder="Nothing to show..."
-                                        rows="5"
-                                    >
-                                        {{ $this->parsed_urls }}
-                                    </flux:textarea>
-                                </flux:field>
+                                        label="Polling Headers (one per line, format: Header: Value)"
+                                        wire:model="polling_header"
+                                        id="polling_header"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_header"
+                                        rows="3"
+                                        placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
+                                    />
+                                </div>
+
+                                @if($polling_verb === 'post')
+                                <div class="mb-4">
+                                    <flux:textarea
+                                        label="Polling Body (e.g. for GraphQL queries)"
+                                        wire:model="polling_body"
+                                        id="polling_body"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_body"
+                                        rows="6"
+                                    />
+                                </div>
+                                @endif
+
+                                <div class="mb-4">
+                                    <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
+                                                id="data_stale_minutes"
+                                                class="block mt-1 w-full" type="number" name="data_stale_minutes"/>
+                                </div>
                             </div>
 
-                            <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
-                                Fetch data now
-                            </flux:button>
+                            {{-- Transform tab --}}
+                            @if(app(ServerlessTransformService::class)->isEnabled())
+                            <div x-show="subTab === 'transform'" x-cloak>
+                                <div class="mb-4">
+                                    <flux:checkbox
+                                        :checked="$transform_code !== null"
+                                        wire:click="{{ $transform_code === null ? 'enableTransform' : 'disableTransform' }}"
+                                        label="Enable transform"
+                                        description="Run a serverless function to reshape the polled data before rendering."
+                                    />
+                                </div>
+
+                                @if($transform_code !== null)
+                                <div>
+                                    <flux:radio.group wire:model.live="transform_language" label="Language" variant="segmented">
+                                        <flux:radio value="python" label="Python"/>
+                                        <flux:radio value="node" label="Node"/>
+                                        <flux:radio value="php" label="PHP"/>
+                                    </flux:radio.group>
+                                </div>
+                                @endif
+                            </div>
+                            @endif
                         </div>
                     </div>
-
-                        <div class="mb-4">
-                            <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
-                                <flux:radio value="get" label="GET"/>
-                                <flux:radio value="post" label="POST"/>
-                            </flux:radio.group>
-                        </div>
-
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Headers (one per line, format: Header: Value)"
-                                wire:model="polling_header"
-                                id="polling_header"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_header"
-                                rows="3"
-                                placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
-                            />
-                        </div>
-
-                        @if($polling_verb === 'post')
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Body (e.g. for GraphQL queries)"
-                                wire:model="polling_body"
-                                id="polling_body"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_body"
-                                rows="6"
-                            />
-                        </div>
-                        @endif
-                        <div class="mb-4">
-                            <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
-                                        id="data_stale_minutes"
-                                        class="block mt-1 w-full" type="number" name="data_stale_minutes" autofocus/>
-                        </div>
                     @elseif($data_strategy === 'webhook')
                         <div class="mb-4">
                             <flux:field>
@@ -1341,7 +1453,7 @@ HTML;
         </div>
         <flux:separator class="my-5"/>
         <div>
-            <h3 class="text-xl font-semibold dark:text-gray-100">Markup</h3>
+            <h3 class="text-xl font-semibold dark:text-gray-100">Code</h3>
             @if($plugin->render_markup_view)
                 <div>
                     Edit view
@@ -1401,163 +1513,149 @@ HTML;
             @endif
         </div>
         @if(!$plugin->render_markup_view)
-            <form wire:submit="saveMarkup">
-                <div class="mb-4">
-                    <div>
-                        <div class="flex items-end">
-                            @foreach($active_tabs as $tab)
-                                <button
-                                    type="button"
-                                    wire:click="switchTab('{{ $tab }}')"
-                                    class="tab-button {{ $active_tab === $tab ? 'is-active' : '' }}"
-                                    wire:key="tab-{{ $tab }}"
-                                >
-                                    {{ $this->getLayoutLabel($tab) }}
-                                </button>
-                            @endforeach
+            <div class="mb-4">
+                <div>
+                    <div class="flex items-end">
+                        @foreach($active_tabs as $tab)
+                            <button
+                                type="button"
+                                wire:click="switchTab('{{ $tab }}')"
+                                class="tab-button {{ $active_tab === $tab ? 'is-active' : '' }}"
+                                wire:key="tab-{{ $tab }}"
+                            >
+                                {{ $this->getLayoutLabel($tab) }}
+                            </button>
+                        @endforeach
 
-                            <flux:dropdown>
-                                <flux:button icon="plus" variant="ghost" size="sm" class="m-0.5"></flux:button>
-                                <flux:menu>
-                                    @foreach($this->getAvailableLayouts() as $layout => $label)
-                                        <flux:menu.item wire:click="toggleLayoutTab('{{ $layout }}')">
-                                            <div class="flex items-center gap-2">
-                                                @if(in_array($layout, $active_tabs, true))
-                                                    <flux:icon.check class="size-4" />
-                                                @else
-                                                    <span class="inline-block w-4 h-4"></span>
-                                                @endif
-                                                <span>{{ $label }}</span>
-                                            </div>
-                                        </flux:menu.item>
-                                    @endforeach
-                                </flux:menu>
-                            </flux:dropdown>
-                        </div>
+                        @if($transform_code !== null && app(ServerlessTransformService::class)->isEnabled())
+                            <button
+                                type="button"
+                                wire:click="switchTab('transform')"
+                                class="tab-button {{ $active_tab === 'transform' ? 'is-active' : '' }}"
+                            >
+                                Transform
+                            </button>
+                        @endif
 
-                        <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
-                            <flux:field>
-                                @php
-                                    $textareaId = 'code-' . $plugin->id;
-                                @endphp
-                                <flux:label>{{ $markup_language === 'liquid' ? 'Liquid Code' : 'Blade Code' }}</flux:label>
-                                <flux:textarea
-                                    wire:model="markup_code"
-                                    id="{{ $textareaId }}"
-                                    placeholder="Enter your HTML code here..."
-                                    rows="25"
-                                    hidden
-                                />
-                                <div
-                                    x-data="codeEditorFormComponent({
-                                        isDisabled: false,
-                                        language: @js($markup_language === 'liquid' ? 'liquid' : 'html'),
-                                        state: $wire.entangle('markup_code'),
-                                        textareaId: @js($textareaId)
-                                    })"
-                                    wire:ignore
-                                    wire:key="cm-{{ $textareaId }}"
-                                    class="min-h-[300px] h-[300px] overflow-hidden resize-y"
-                                >
-                                    <!-- Loading state -->
-                                    <div x-show="isLoading" class="flex items-center justify-center h-full">
-                                        <div class="flex items-center space-x-2">
-                                            <flux:icon.loading />
+                        <flux:dropdown>
+                            <flux:button icon="plus" variant="ghost" size="sm" class="m-0.5"></flux:button>
+                            <flux:menu>
+                                @foreach($this->getAvailableLayouts() as $layout => $label)
+                                    <flux:menu.item wire:click="toggleLayoutTab('{{ $layout }}')">
+                                        <div class="flex items-center gap-2">
+                                            @if(in_array($layout, $active_tabs, true))
+                                                <flux:icon.check class="size-4" />
+                                            @else
+                                                <span class="inline-block w-4 h-4"></span>
+                                            @endif
+                                            <span>{{ $label }}</span>
                                         </div>
-                                    </div>
-
-                                    <!-- Editor container -->
-                                    <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
-                                </div>
-                            </flux:field>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="flex">
-                    <flux:button type="submit" variant="primary">
-                        Save
-                    </flux:button>
-                </div>
-            </form>
-        @endif
-    </div>
-
-        <flux:separator class="my-5"/>
-        <div>
-            <h3 class="text-xl font-semibold dark:text-gray-100">Transform</h3>
-
-            @if(!app(ServerlessTransformService::class)->isEnabled())
-                <flux:callout class="mt-4" variant="warning" icon="exclamation-circle"
-                    heading="Serverless transforms are disabled."
-                    text="Set TRANSFORM_RUNNER_URL to enable the transform runner." />
-            @elseif($transform_code === null)
-                <div class="mt-4">
-                    <flux:button icon="plus" wire:click="addTransform">Add Transform</flux:button>
-                </div>
-            @else
-                <div class="mt-4">
-                    <div class="flex items-center gap-4 mb-4">
-                        <flux:radio.group wire:model.live="transform_language" label="Language" variant="segmented">
-                            <flux:radio value="python" label="Python"/>
-                            <flux:radio value="node" label="Node"/>
-                            <flux:radio value="php" label="PHP"/>
-                        </flux:radio.group>
+                                    </flux:menu.item>
+                                @endforeach
+                            </flux:menu>
+                        </flux:dropdown>
                     </div>
 
-                    @php $transformTextareaId = 'transform-' . $plugin->id; @endphp
-                    <flux:textarea wire:model="transform_code" id="{{ $transformTextareaId }}" rows="20" hidden/>
-                    <div
-                        x-data="codeEditorFormComponent({
-                            isDisabled: false,
-                            language: @js(match($transform_language) { 'node' => 'javascript', 'php' => 'php', default => 'python' }),
-                            state: $wire.entangle('transform_code'),
-                            textareaId: @js($transformTextareaId)
-                        })"
-                        wire:ignore
-                        wire:key="cm-transform-{{ $plugin->id }}-{{ $transform_language }}"
-                        class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
-                    >
-                        <div x-show="isLoading" class="flex items-center justify-center h-full">
-                            <flux:icon.loading />
-                        </div>
-                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
-                    </div>
-
-                    <div class="flex gap-2 mb-4">
-                        <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
-                            <span wire:loading.remove wire:target="runTransform">Run</span>
-                            <span wire:loading wire:target="runTransform">Running...</span>
-                        </flux:button>
-                        <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
-                    </div>
-
-                    @if($transform_run_output !== null)
-                        <div class="mt-2">
-                            <flux:label>Transform Output</flux:label>
-                            @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
-                            <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
+                    <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
+                        @if($active_tab === 'transform')
+                            {{-- Transform code editor --}}
+                            @php $transformTextareaId = 'transform-' . $plugin->id; @endphp
+                            <flux:textarea wire:model="transform_code" id="{{ $transformTextareaId }}" rows="20" hidden/>
                             <div
                                 x-data="codeEditorFormComponent({
-                                    isDisabled: true,
-                                    language: 'json',
-                                    state: $wire.entangle('transform_run_output'),
-                                    textareaId: @js($outputTextareaId)
+                                    isDisabled: false,
+                                    language: @js(match($transform_language) { 'node' => 'javascript', 'php' => 'php', default => 'python' }),
+                                    state: $wire.entangle('transform_code'),
+                                    textareaId: @js($transformTextareaId)
                                 })"
                                 wire:ignore
-                                wire:key="cm-{{ $outputTextareaId }}"
-                                class="min-h-[200px] h-[200px] overflow-hidden resize-y"
+                                wire:key="cm-transform-{{ $plugin->id }}-{{ $transform_language }}"
+                                class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
                             >
                                 <div x-show="isLoading" class="flex items-center justify-center h-full">
                                     <flux:icon.loading />
                                 </div>
                                 <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
                             </div>
-                        </div>
-                    @endif
+
+                            @if($transform_run_output !== null)
+                                <div class="mt-2 mb-4">
+                                    <flux:label>Transform Output</flux:label>
+                                    @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
+                                    <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
+                                    <div
+                                        x-data="codeEditorFormComponent({
+                                            isDisabled: true,
+                                            language: 'json',
+                                            state: $wire.entangle('transform_run_output'),
+                                            textareaId: @js($outputTextareaId)
+                                        })"
+                                        wire:ignore
+                                        wire:key="cm-{{ $outputTextareaId }}"
+                                        class="min-h-[200px] h-[200px] overflow-hidden resize-y"
+                                    >
+                                        <div x-show="isLoading" class="flex items-center justify-center h-full">
+                                            <flux:icon.loading />
+                                        </div>
+                                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                                    </div>
+                                </div>
+                            @endif
+
+                            <div class="flex gap-2">
+                                <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
+                                    <span wire:loading.remove wire:target="runTransform">Run</span>
+                                    <span wire:loading wire:target="runTransform">Running...</span>
+                                </flux:button>
+                                <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
+                            </div>
+                        @else
+                            {{-- Markup code editor --}}
+                            <form wire:submit="saveMarkup">
+                                <flux:field>
+                                    @php
+                                        $textareaId = 'code-' . $plugin->id;
+                                    @endphp
+                                    <flux:label>{{ $markup_language === 'liquid' ? 'Liquid Code' : 'Blade Code' }}</flux:label>
+                                    <flux:textarea
+                                        wire:model="markup_code"
+                                        id="{{ $textareaId }}"
+                                        placeholder="Enter your HTML code here..."
+                                        rows="25"
+                                        hidden
+                                    />
+                                    <div
+                                        x-data="codeEditorFormComponent({
+                                            isDisabled: false,
+                                            language: @js($markup_language === 'liquid' ? 'liquid' : 'html'),
+                                            state: $wire.entangle('markup_code'),
+                                            textareaId: @js($textareaId)
+                                        })"
+                                        wire:ignore
+                                        wire:key="cm-{{ $textareaId }}"
+                                        class="min-h-[300px] h-[300px] overflow-hidden resize-y"
+                                    >
+                                        <div x-show="isLoading" class="flex items-center justify-center h-full">
+                                            <div class="flex items-center space-x-2">
+                                                <flux:icon.loading />
+                                            </div>
+                                        </div>
+                                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                                    </div>
+                                </flux:field>
+
+                                <div class="flex mt-4">
+                                    <flux:button type="submit" variant="primary">
+                                        Save
+                                    </flux:button>
+                                </div>
+                            </form>
+                        @endif
+                    </div>
                 </div>
-            @endif
-        </div>
+            </div>
+        @endif
+    </div>
     </div>
 </div>
 

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1316,20 +1316,6 @@ HTML;
 
                 </div>
             @else
-            <div class="flex items-center gap-6 mb-4 mt-4">
-                <div class="flex-1 flex items-center">
-                    <span class="pr-2">Template language</span>
-                    <flux:radio.group wire:model.live="markup_language" variant="segmented">
-                        <flux:radio value="blade" label="Blade"/>
-                        <flux:radio value="liquid" label="Liquid"/>
-                    </flux:radio.group>
-                </div>
-                <div class="text-accent flex items-center gap-2">
-                    <span class="pr-2">Getting started</span>
-                    <flux:button wire:click="renderExample('layoutTitle')" class="text-xl">Responsive Layout with Title Bar</flux:button>
-                    <flux:button wire:click="renderExample('layout')" class="text-xl">Responsive Layout</flux:button>
-                </div>
-            </div>
             @endif
         </div>
         @if(!$plugin->render_markup_view)
@@ -1410,6 +1396,21 @@ HTML;
                     <flux:button type="submit" variant="primary">
                         Save
                     </flux:button>
+                </div>
+
+                <div class="flex items-center gap-3 mt-4">
+                    <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Template language</span>
+                    <flux:select wire:model.live="markup_language" class="max-w-xs">
+                        <flux:select.option value="blade">Blade</flux:select.option>
+                        <flux:select.option value="liquid">Liquid</flux:select.option>
+                    </flux:select>
+                </div>
+
+                <div class="flex items-center gap-3 mt-3">
+                    <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Getting started</span>
+                    <flux:button size="sm" wire:click="renderExample('layoutTitle')">Responsive Layout with Title Bar</flux:button>
+                    <flux:button size="sm" wire:click="renderExample('layout')">Responsive Layout</flux:button>
+                    <span class="text-xs text-zinc-400 dark:text-zinc-500">These will replace the current template.</span>
                 </div>
             </form>
         @endif

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -93,7 +93,6 @@ new class extends Component
         Flux::toast(variant: 'success', text: 'Plugin ownership updated.');
     }
 
-
     public function mount(): void
     {
         abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1575,13 +1575,9 @@ HTML;
                                 </div>
                                 <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
                             </div>
-
-                            <div class="flex gap-2">
-                                <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
-                            </div>
                         @else
                             {{-- Markup code editor --}}
-                            <form wire:submit="saveMarkup">
+                            <div>
                                 <flux:field>
                                     @php
                                         $textareaId = 'code-' . $plugin->id;
@@ -1613,19 +1609,16 @@ HTML;
                                         <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
                                     </div>
                                 </flux:field>
-
-                                <div class="flex mt-4">
-                                    <flux:button type="submit" variant="primary">
-                                        Save
-                                    </flux:button>
-                                </div>
-                            </form>
+                            </div>
                         @endif
                     </div>
                 </div>
 
-                <div class="flex">
-                    <flux:button type="submit" variant="primary">
+                <div class="flex mt-4">
+                    <flux:button
+                        variant="primary"
+                        wire:click="{{ $active_tab === 'transform' ? 'saveTransform' : 'saveMarkup' }}"
+                    >
                         Save
                     </flux:button>
                 </div>
@@ -1644,7 +1637,6 @@ HTML;
                     <flux:button size="sm" wire:click="renderExample('layout')">Responsive Layout</flux:button>
                     <span class="text-xs text-zinc-400 dark:text-zinc-500">These will replace the current template.</span>
                 </div>
-            </form>
         @endif
     </div>
     </div>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -14,6 +14,8 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 new class extends Component
 {
+    use \Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+
     public Plugin $plugin;
 
     public ?string $markup_code;
@@ -74,9 +76,27 @@ new class extends Component
 
     public string $active_tab = 'full';
 
+
+    public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
+    {
+        return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
+    }
+
+    public function reassignPlugin(int $newOwnerId): void
+    {
+        $this->authorize('reassign', $this->plugin);
+
+        $newOwner = \App\Models\User::findOrFail($newOwnerId);
+        $this->plugin->update(['user_id' => $newOwner->id]);
+        $this->plugin = $this->plugin->fresh();
+
+        Flux::toast(variant: 'success', text: 'Plugin ownership updated.');
+    }
+
+
     public function mount(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->blade_code = $this->plugin->render_markup;
         // required to render some stuff
         $this->configuration_template = $this->plugin->configuration_template ?? [];
@@ -733,7 +753,7 @@ HTML;
     "
 >
     <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
-        <div class="flex justify-between items-center mb-6">
+        <div class="flex justify-between items-center mb-3">
             <h2 class="text-2xl font-semibold dark:text-gray-100">{{$plugin->name}}
                 <flux:badge size="sm" class="ml-2">Recipe</flux:badge>
             </h2>
@@ -783,6 +803,19 @@ HTML;
                 </flux:dropdown>
             </flux:button.group>
         </div>
+
+        @if(auth()->user()->isAdmin())
+            <div class="flex items-center gap-3 mb-6">
+                <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Owner</span>
+                <flux:select wire:change="reassignPlugin($event.target.value)" class="max-w-xs">
+                    @foreach ($this->availableUsers as $u)
+                        <flux:select.option value="{{ $u->id }}" :selected="$plugin->user_id === $u->id">
+                            {{ $u->name }}
+                        </flux:select.option>
+                    @endforeach
+                </flux:select>
+            </div>
+        @endif
 
         <flux:modal name="add-to-playlist" class="min-w-2xl">
             <div class="space-y-6">

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1093,8 +1093,17 @@ HTML;
                     @if($data_strategy === 'polling')
                     <flux:label>Polling URL</flux:label>
 
-                    <div x-data="{ subTab: 'settings' }" class="mt-2 mb-4">
+                    <div x-data="{ subTab: 'urls' }" class="mt-2 mb-4">
                         <div class="flex">
+                            <button
+                                @click="subTab = 'urls'"
+                                class="tab-button"
+                                :class="subTab === 'urls' ? 'is-active' : ''"
+                            >
+                                <flux:icon.link class="size-4"/>
+                                URLs
+                            </button>
+
                             <button
                                 @click="subTab = 'settings'"
                                 class="tab-button"
@@ -1103,19 +1112,11 @@ HTML;
                                 <flux:icon.cog-6-tooth class="size-4"/>
                                 Settings
                             </button>
-
-                            <button
-                                @click="subTab = 'preview'"
-                                class="tab-button"
-                                :class="subTab === 'preview' ? 'is-active' : ''"
-                            >
-                                <flux:icon.eye class="size-4" />
-                                Preview URL
-                            </button>
                         </div>
 
                         <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
-                            <div x-show="subTab === 'settings'">
+                            {{-- URLs tab --}}
+                            <div x-show="subTab === 'urls'">
                                 <flux:field>
                                     <flux:description>Enter the URL(s) to poll for data:</flux:description>
                                     <flux:textarea
@@ -1127,63 +1128,67 @@ HTML;
                                         {!! 'Hint: Supports multiple requests via line break separation. You can also use configuration variables with <a href="https://help.usetrmnl.com/en/articles/12689499-dynamic-polling-urls">Liquid syntax</a>. ' !!}
                                     </flux:description>
                                 </flux:field>
+
+                                <div class="mt-3">
+                                    <flux:field>
+                                        <flux:description>Preview computed URLs here (readonly):</flux:description>
+                                        <flux:textarea
+                                            readonly
+                                            placeholder="Nothing to show..."
+                                            rows="3"
+                                        >
+                                            {{ $this->parsed_urls }}
+                                        </flux:textarea>
+                                    </flux:field>
+                                </div>
+
+                                <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
+                                    Fetch data now
+                                </flux:button>
                             </div>
 
-                            <div x-show="subTab === 'preview'" x-cloak>
-                                <flux:field>
-                                    <flux:description>Preview computed URLs here (readonly):</flux:description>
+                            {{-- Settings tab --}}
+                            <div x-show="subTab === 'settings'" x-cloak>
+                                <div class="mb-4">
+                                    <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
+                                        <flux:radio value="get" label="GET"/>
+                                        <flux:radio value="post" label="POST"/>
+                                    </flux:radio.group>
+                                </div>
+
+                                <div class="mb-4">
                                     <flux:textarea
-                                        readonly
-                                        placeholder="Nothing to show..."
-                                        rows="5"
-                                    >
-                                        {{ $this->parsed_urls }}
-                                    </flux:textarea>
-                                </flux:field>
-                            </div>
+                                        label="Polling Headers (one per line, format: Header: Value)"
+                                        wire:model="polling_header"
+                                        id="polling_header"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_header"
+                                        rows="3"
+                                        placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
+                                    />
+                                </div>
 
-                            <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
-                                Fetch data now
-                            </flux:button>
+                                @if($polling_verb === 'post')
+                                <div class="mb-4">
+                                    <flux:textarea
+                                        label="Polling Body (e.g. for GraphQL queries)"
+                                        wire:model="polling_body"
+                                        id="polling_body"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_body"
+                                        rows="6"
+                                    />
+                                </div>
+                                @endif
+
+                                <div class="mb-4">
+                                    <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
+                                                id="data_stale_minutes"
+                                                class="block mt-1 w-full" type="number" name="data_stale_minutes"/>
+                                </div>
+                            </div>
                         </div>
                     </div>
-
-                        <div class="mb-4">
-                            <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
-                                <flux:radio value="get" label="GET"/>
-                                <flux:radio value="post" label="POST"/>
-                            </flux:radio.group>
-                        </div>
-
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Headers (one per line, format: Header: Value)"
-                                wire:model="polling_header"
-                                id="polling_header"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_header"
-                                rows="3"
-                                placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
-                            />
-                        </div>
-
-                        @if($polling_verb === 'post')
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Body (e.g. for GraphQL queries)"
-                                wire:model="polling_body"
-                                id="polling_body"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_body"
-                                rows="6"
-                            />
-                        </div>
-                        @endif
-                        <div class="mb-4">
-                            <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
-                                        id="data_stale_minutes"
-                                        class="block mt-1 w-full" type="number" name="data_stale_minutes" autofocus/>
-                        </div>
                     @elseif($data_strategy === 'webhook')
                         <div class="mb-4">
                             <flux:field>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -906,20 +906,6 @@ HTML;
             </div>
         </div>
 
-        @if(config('app.multi_user_mode') && auth()->user()->isAdmin())
-            <div class="flex items-center gap-3 mb-6">
-                <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Owner</span>
-                <flux:select wire:change="reassignPlugin($event.target.value)" class="max-w-xs">
-                    <flux:select.option value="" :selected="$plugin->user_id === null">— Unowned —</flux:select.option>
-                    @foreach ($this->availableUsers as $u)
-                        <flux:select.option value="{{ $u->id }}" :selected="$plugin->user_id === $u->id">
-                            {{ $u->name }}
-                        </flux:select.option>
-                    @endforeach
-                </flux:select>
-            </div>
-        @endif
-
         <flux:modal name="add-to-playlist" class="min-w-2xl">
             <div class="space-y-6">
                 <div>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -137,7 +137,8 @@ new class extends Component
             }
 
             $this->markup_code = $this->markup_layouts['full'];
-            $this->markup_language = $this->plugin->markup_language ?? 'blade';
+            $canUseBlade = auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
+            $this->markup_language = $this->plugin->markup_language ?? ($canUseBlade ? 'blade' : 'liquid');
         }
 
         // Initialize screen settings from the model
@@ -284,7 +285,15 @@ new class extends Component
         'polling_body' => 'nullable|string',
         'data_payload' => 'required_if:data_strategy,static|nullable|json',
         'markup_code' => 'nullable|string',
-        'markup_language' => 'nullable|string|in:blade,liquid',
+        'markup_language' => ['nullable', 'string', function ($attribute, $value, $fail) {
+            $allowed = ['liquid'];
+            if (auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins')) {
+                $allowed[] = 'blade';
+            }
+            if (! in_array($value, $allowed)) {
+                $fail('Blade templates are restricted to administrators.');
+            }
+        }],
         'checked_devices' => 'array',
         'device_playlist_names' => 'array',
         'device_playlists' => 'array',
@@ -1352,7 +1361,9 @@ HTML;
                 <div class="flex-1 flex items-center">
                     <span class="pr-2">Template language</span>
                     <flux:radio.group wire:model.live="markup_language" variant="segmented">
+                        @if(auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins'))
                         <flux:radio value="blade" label="Blade"/>
+                        @endif
                         <flux:radio value="liquid" label="Liquid"/>
                     </flux:radio.group>
                 </div>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -81,6 +81,8 @@ new class extends Component
 
     public ?string $transform_language = 'python';
 
+    public ?string $transform_error = null;
+
     public bool $is_shared = false;
 
     public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
@@ -386,6 +388,12 @@ new class extends Component
                 $this->data_payload = json_encode($this->plugin->data_payload, JSON_PRETTY_PRINT);
                 $this->data_payload_updated_at = $this->plugin->data_payload_updated_at;
 
+                $payload = $this->plugin->data_payload;
+                if ($this->transform_code !== null && is_array($payload) && array_key_exists('error', $payload)) {
+                    $this->transform_error = (string) ($payload['error'] ?? 'Unknown transform error');
+                } else {
+                    $this->transform_error = null;
+                }
             } catch (Exception $e) {
                 $this->dispatch('data-update-error', message: $e->getMessage().$e->getPrevious()?->getMessage());
             }
@@ -1383,6 +1391,9 @@ HTML;
                     @isset($this->data_payload_updated_at)
                         <flux:badge icon="clock" size="sm" variant="pill" class="ml-2">{{ $this->data_payload_updated_at?->diffForHumans() ?? 'Never' }}</flux:badge>
                     @endisset
+                    @if($transform_error !== null)
+                        <flux:badge icon="exclamation-triangle" size="sm" variant="pill" color="red" class="ml-2" :title="$transform_error">Transform error</flux:badge>
+                    @endif
                 </div>
                 <flux:error name="data_payload"/>
                 <flux:field>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -81,8 +81,6 @@ new class extends Component
 
     public ?string $transform_language = 'python';
 
-    public ?string $transform_run_output = null;
-
     public bool $is_shared = false;
 
     public function getAvailableUsersProperty(): \Illuminate\Database\Eloquent\Collection
@@ -759,7 +757,6 @@ HTML;
     {
         abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->transform_code = null;
-        $this->transform_run_output = null;
         $this->plugin->update(['transform_code' => null, 'transform_language' => null]);
         if ($this->active_tab === 'transform') {
             $this->active_tab = 'full';
@@ -785,29 +782,6 @@ HTML;
         ]);
 
         Flux::toast(variant: 'success', text: 'Transform saved.');
-    }
-
-    public function runTransform(): void
-    {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
-
-        if (! $this->plugin->data_payload) {
-            $this->dispatch('transform-error', message: 'Fetch data first before running the transform.');
-
-            return;
-        }
-
-        try {
-            $result = app(ServerlessTransformService::class)->run(
-                $this->transform_code ?? '',
-                $this->transform_language ?? 'python',
-                $this->plugin->data_payload,
-                strict: true,
-            );
-            $this->transform_run_output = json_encode($result, JSON_PRETTY_PRINT);
-        } catch (\Throwable $e) {
-            $this->dispatch('transform-error', message: $e->getMessage());
-        }
     }
 
     #[On('config-updated')]
@@ -1578,35 +1552,7 @@ HTML;
                                 <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
                             </div>
 
-                            @if($transform_run_output !== null)
-                                <div class="mt-2 mb-4">
-                                    <flux:label>Transform Output</flux:label>
-                                    @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
-                                    <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
-                                    <div
-                                        x-data="codeEditorFormComponent({
-                                            isDisabled: true,
-                                            language: 'json',
-                                            state: $wire.entangle('transform_run_output'),
-                                            textareaId: @js($outputTextareaId)
-                                        })"
-                                        wire:ignore
-                                        wire:key="cm-{{ $outputTextareaId }}"
-                                        class="min-h-[200px] h-[200px] overflow-hidden resize-y"
-                                    >
-                                        <div x-show="isLoading" class="flex items-center justify-center h-full">
-                                            <flux:icon.loading />
-                                        </div>
-                                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
-                                    </div>
-                                </div>
-                            @endif
-
                             <div class="flex gap-2">
-                                <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
-                                    <span wire:loading.remove wire:target="runTransform">Run</span>
-                                    <span wire:loading wire:target="runTransform">Running...</span>
-                                </flux:button>
                                 <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
                             </div>
                         @else
@@ -1784,10 +1730,6 @@ HTML;
 
     $wire.on('data-update-error', ({message}) => {
         alert('Data Update Error: ' + message);
-    });
-
-    $wire.on('transform-error', ({message}) => {
-        alert('Transform Error: ' + message);
     });
 </script>
 @endscript

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -733,6 +733,7 @@ HTML;
                 $this->transform_code ?? '',
                 $this->transform_language ?? 'python',
                 $this->plugin->data_payload,
+                strict: true,
             );
             $this->transform_run_output = json_encode($result, JSON_PRETTY_PRINT);
         } catch (\Throwable $e) {
@@ -1501,7 +1502,7 @@ HTML;
                             textareaId: @js($transformTextareaId)
                         })"
                         wire:ignore
-                        wire:key="cm-{{ $transformTextareaId }}"
+                        wire:key="cm-transform-{{ $plugin->id }}-{{ $transform_language }}"
                         class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
                     >
                         <div x-show="isLoading" class="flex items-center justify-center h-full">

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1466,9 +1466,6 @@ HTML;
             </form>
         @endif
     </div>
-</div>
-
-
 
         <flux:separator class="my-5"/>
         <div>
@@ -1545,6 +1542,8 @@ HTML;
                 </div>
             @endif
         </div>
+    </div>
+</div>
 
 @script
 <script>

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1116,6 +1116,7 @@ HTML;
                     @if(auth()->user()->isAdmin())
                         <div class="mb-4">
                             <flux:select label="Owner" wire:change="reassignPlugin($event.target.value)">
+                                <flux:select.option value="" :selected="$plugin->user_id === null">— Unowned —</flux:select.option>
                                 @foreach ($this->availableUsers as $u)
                                     <flux:select.option value="{{ $u->id }}" :selected="$plugin->user_id === $u->id">
                                         {{ $u->name }}

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -804,7 +804,7 @@ HTML;
             </flux:button.group>
         </div>
 
-        @if(auth()->user()->isAdmin())
+        @if(config('app.multi_user_mode') && auth()->user()->isAdmin())
             <div class="flex items-center gap-3 mb-6">
                 <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Owner</span>
                 <flux:select wire:change="reassignPlugin($event.target.value)" class="max-w-xs">

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -82,12 +82,12 @@ new class extends Component
         return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
     }
 
-    public function reassignPlugin(int $newOwnerId): void
+    public function reassignPlugin(?int $newOwnerId): void
     {
         $this->authorize('reassign', $this->plugin);
 
-        $newOwner = \App\Models\User::findOrFail($newOwnerId);
-        $this->plugin->update(['user_id' => $newOwner->id]);
+        $newOwner = $newOwnerId ? \App\Models\User::findOrFail($newOwnerId) : null;
+        $this->plugin->update(['user_id' => $newOwner?->id]);
         $this->plugin = $this->plugin->fresh();
 
         Flux::toast(variant: 'success', text: 'Plugin ownership updated.');
@@ -137,7 +137,7 @@ new class extends Component
             }
 
             $this->markup_code = $this->markup_layouts['full'];
-            $canUseBlade = auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
+            $canUseBlade = ! config('app.multi_user_mode') || auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins');
             $this->markup_language = $this->plugin->markup_language ?? ($canUseBlade ? 'blade' : 'liquid');
         }
 
@@ -171,7 +171,7 @@ new class extends Component
 
     public function saveMarkup(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->validate();
 
         // Update markup_code for the active tab
@@ -275,38 +275,41 @@ new class extends Component
         return 'Responsive';
     }
 
-    protected array $rules = [
-        'name' => 'required|string|max:255',
-        'data_stale_minutes' => 'required|integer|min:1',
-        'data_strategy' => 'required|string|in:polling,webhook,static',
-        'polling_url' => 'required_if:data_strategy,polling|nullable',
-        'polling_verb' => 'required|string|in:get,post',
-        'polling_header' => 'nullable|string|max:10240',
-        'polling_body' => 'nullable|string',
-        'data_payload' => 'required_if:data_strategy,static|nullable|json',
-        'markup_code' => 'nullable|string',
-        'markup_language' => ['nullable', 'string', function ($attribute, $value, $fail) {
-            $allowed = ['liquid'];
-            if (auth()->user()->isAdmin() || config('app.dangerously_allow_blade_for_non_admins')) {
-                $allowed[] = 'blade';
-            }
-            if (! in_array($value, $allowed)) {
-                $fail('Blade templates are restricted to administrators.');
-            }
-        }],
-        'checked_devices' => 'array',
-        'device_playlist_names' => 'array',
-        'device_playlists' => 'array',
-        'device_weekdays' => 'array',
-        'device_active_from' => 'array',
-        'device_active_until' => 'array',
-        'no_bleed' => 'boolean',
-        'dark_mode' => 'boolean',
-    ];
+    protected function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'data_stale_minutes' => 'required|integer|min:1',
+            'data_strategy' => 'required|string|in:polling,webhook,static',
+            'polling_url' => 'required_if:data_strategy,polling|nullable',
+            'polling_verb' => 'required|string|in:get,post',
+            'polling_header' => 'nullable|string|max:10240',
+            'polling_body' => 'nullable|string',
+            'data_payload' => 'required_if:data_strategy,static|nullable|json',
+            'markup_code' => 'nullable|string',
+            'markup_language' => ['nullable', 'string', function ($attribute, $value, $fail) {
+                $allowed = ['liquid'];
+                if (! config('app.multi_user_mode') || auth()->user()?->isAdmin() || config('app.dangerously_allow_blade_for_non_admins')) {
+                    $allowed[] = 'blade';
+                }
+                if (! in_array($value, $allowed)) {
+                    $fail('Blade templates are restricted to administrators.');
+                }
+            }],
+            'checked_devices' => 'array',
+            'device_playlist_names' => 'array',
+            'device_playlists' => 'array',
+            'device_weekdays' => 'array',
+            'device_active_from' => 'array',
+            'device_active_until' => 'array',
+            'no_bleed' => 'boolean',
+            'dark_mode' => 'boolean',
+        ];
+    }
 
     public function editSettings()
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
 
         // Custom validation for polling_url with Liquid variable resolution
         $this->validatePollingUrl();
@@ -543,7 +546,7 @@ HTML;
 
     public function renderPreview($size = 'full'): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
 
         $this->preview_size = $size;
 
@@ -604,7 +607,7 @@ HTML;
 
     public function renderImage(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
 
         if ($this->plugin->data_strategy === 'polling' && $this->plugin->data_payload === null) {
             $this->updateData();
@@ -694,7 +697,7 @@ HTML;
 
     public function duplicatePlugin(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
 
         // Use the model's duplicate method
         $newPlugin = $this->plugin->duplicate(auth()->id());
@@ -705,14 +708,14 @@ HTML;
 
     public function exportPluginArchive(PluginExportService $exporter): BinaryFileResponse
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
 
         return $exporter->exportToZip($this->plugin, auth()->user());
     }
 
     public function deletePlugin(): void
     {
-        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        abort_unless(auth()->user()->isAdmin() || auth()->user()->plugins->contains($this->plugin), 403);
         $this->plugin->delete();
         $this->redirect(route('plugins.index'));
     }
@@ -816,6 +819,7 @@ HTML;
             <div class="flex items-center gap-3 mb-6">
                 <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Owner</span>
                 <flux:select wire:change="reassignPlugin($event.target.value)" class="max-w-xs">
+                    <flux:select.option value="" :selected="$plugin->user_id === null">— Unowned —</flux:select.option>
                     @foreach ($this->availableUsers as $u)
                         <flux:select.option value="{{ $u->id }}" :selected="$plugin->user_id === $u->id">
                             {{ $u->name }}

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -3,6 +3,7 @@
 use App\Models\Device;
 use App\Models\DeviceModel;
 use App\Models\Plugin;
+use App\Services\Plugin\ServerlessTransformService;
 use App\Services\PluginExportService;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -74,6 +75,12 @@ new class extends Component
 
     public string $active_tab = 'full';
 
+    public ?string $transform_code = null;
+
+    public ?string $transform_language = 'python';
+
+    public ?string $transform_run_output = null;
+
     public function mount(): void
     {
         abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
@@ -124,6 +131,9 @@ new class extends Component
         // Initialize screen settings from the model
         $this->no_bleed = (bool) ($this->plugin->no_bleed ?? false);
         $this->dark_mode = (bool) ($this->plugin->dark_mode ?? false);
+
+        $this->transform_code = $this->plugin->transform_code;
+        $this->transform_language = $this->plugin->transform_language ?? 'python';
 
         $this->fillformFields();
         $this->data_payload_updated_at = $this->plugin->data_payload_updated_at;
@@ -274,6 +284,8 @@ new class extends Component
         'device_active_until' => 'array',
         'no_bleed' => 'boolean',
         'dark_mode' => 'boolean',
+        'transform_code' => 'nullable|string',
+        'transform_language' => 'nullable|string|in:python,node,php',
     ];
 
     public function editSettings()
@@ -687,6 +699,45 @@ HTML;
         abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
         $this->plugin->delete();
         $this->redirect(route('plugins.index'));
+    }
+
+    public function addTransform(): void
+    {
+        $this->transform_code = '';
+        $this->transform_language = 'python';
+    }
+
+    public function saveTransform(): void
+    {
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+        $this->validate(['transform_code' => 'nullable|string', 'transform_language' => 'nullable|string|in:python,node,php']);
+
+        $this->plugin->update([
+            'transform_code'     => $this->transform_code ?: null,
+            'transform_language' => $this->transform_code ? $this->transform_language : null,
+        ]);
+    }
+
+    public function runTransform(): void
+    {
+        abort_unless(auth()->user()->plugins->contains($this->plugin), 403);
+
+        if (! $this->plugin->data_payload) {
+            $this->dispatch('transform-error', message: 'Fetch data first before running the transform.');
+
+            return;
+        }
+
+        try {
+            $result = app(ServerlessTransformService::class)->run(
+                $this->transform_code ?? '',
+                $this->transform_language ?? 'python',
+                $this->plugin->data_payload,
+            );
+            $this->transform_run_output = json_encode($result, JSON_PRETTY_PRINT);
+        } catch (\Throwable $e) {
+            $this->dispatch('transform-error', message: $e->getMessage());
+        }
     }
 
     #[On('config-updated')]
@@ -1418,6 +1469,82 @@ HTML;
 
 
 
+        <flux:separator class="my-5"/>
+        <div>
+            <h3 class="text-xl font-semibold dark:text-gray-100">Transform</h3>
+
+            @if(!app(ServerlessTransformService::class)->isEnabled())
+                <flux:callout class="mt-4" variant="warning" icon="exclamation-circle"
+                    heading="Serverless transforms are disabled."
+                    text="Set TRANSFORM_RUNNER_URL to enable the transform runner." />
+            @elseif($transform_code === null)
+                <div class="mt-4">
+                    <flux:button icon="plus" wire:click="addTransform">Add Transform</flux:button>
+                </div>
+            @else
+                <div class="mt-4">
+                    <div class="flex items-center gap-4 mb-4">
+                        <flux:radio.group wire:model.live="transform_language" label="Language" variant="segmented">
+                            <flux:radio value="python" label="Python"/>
+                            <flux:radio value="node" label="Node"/>
+                            <flux:radio value="php" label="PHP"/>
+                        </flux:radio.group>
+                    </div>
+
+                    @php $transformTextareaId = 'transform-' . $plugin->id; @endphp
+                    <flux:textarea wire:model="transform_code" id="{{ $transformTextareaId }}" rows="20" hidden/>
+                    <div
+                        x-data="codeEditorFormComponent({
+                            isDisabled: false,
+                            language: @js(match($transform_language) { 'node' => 'javascript', 'php' => 'php', default => 'python' }),
+                            state: $wire.entangle('transform_code'),
+                            textareaId: @js($transformTextareaId)
+                        })"
+                        wire:ignore
+                        wire:key="cm-{{ $transformTextareaId }}"
+                        class="min-h-[300px] h-[300px] overflow-hidden resize-y mb-4"
+                    >
+                        <div x-show="isLoading" class="flex items-center justify-center h-full">
+                            <flux:icon.loading />
+                        </div>
+                        <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                    </div>
+
+                    <div class="flex gap-2 mb-4">
+                        <flux:button icon="play" wire:click="runTransform" wire:loading.attr="disabled" wire:target="runTransform">
+                            <span wire:loading.remove wire:target="runTransform">Run</span>
+                            <span wire:loading wire:target="runTransform">Running...</span>
+                        </flux:button>
+                        <flux:button variant="primary" wire:click="saveTransform">Save</flux:button>
+                    </div>
+
+                    @if($transform_run_output !== null)
+                        <div class="mt-2">
+                            <flux:label>Transform Output</flux:label>
+                            @php $outputTextareaId = 'transform-output-' . $plugin->id; @endphp
+                            <flux:textarea wire:model="transform_run_output" id="{{ $outputTextareaId }}" rows="10" hidden/>
+                            <div
+                                x-data="codeEditorFormComponent({
+                                    isDisabled: true,
+                                    language: 'json',
+                                    state: $wire.entangle('transform_run_output'),
+                                    textareaId: @js($outputTextareaId)
+                                })"
+                                wire:ignore
+                                wire:key="cm-{{ $outputTextareaId }}"
+                                class="min-h-[200px] h-[200px] overflow-hidden resize-y"
+                            >
+                                <div x-show="isLoading" class="flex items-center justify-center h-full">
+                                    <flux:icon.loading />
+                                </div>
+                                <div x-show="!isLoading" x-ref="editor" class="h-full"></div>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            @endif
+        </div>
+
 @script
 <script>
     let previewNativeWidth = 800;
@@ -1543,6 +1670,10 @@ HTML;
 
     $wire.on('data-update-error', ({message}) => {
         alert('Data Update Error: ' + message);
+    });
+
+    $wire.on('transform-error', ({message}) => {
+        alert('Transform Error: ' + message);
     });
 </script>
 @endscript

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -90,6 +90,16 @@ new class extends Component
         return \App\Models\User::whereNotNull('confirmed_at')->orderBy('name')->get();
     }
 
+    public function getManageableDevicesProperty()
+    {
+        $user = auth()->user();
+
+        return Device::where('user_id', $user->id)
+            ->orWhereNull('user_id')
+            ->orderBy('name')
+            ->get();
+    }
+
     public function reassignPlugin(?int $newOwnerId): void
     {
         $this->authorize('reassign', $this->plugin);
@@ -441,6 +451,11 @@ new class extends Component
             'mashup_layout' => 'required|string',
             'mashup_plugins' => 'required_if:mashup_layout,1Lx1R,1Lx2R,2Lx1R,1Tx1B,2Tx1B,1Tx2B,2x2|array',
         ]);
+
+        $manageableIds = $this->manageableDevices->pluck('id')->all();
+        foreach ($this->checked_devices as $deviceId) {
+            abort_unless(in_array((int) $deviceId, $manageableIds, true), 403);
+        }
 
         // Validate that each checked device has a playlist selected
         foreach ($this->checked_devices as $deviceId) {
@@ -916,8 +931,11 @@ HTML;
                     <flux:separator text="Device(s)" />
                     <div class="mt-4 mb-4">
                         <flux:checkbox.group wire:model.live="checked_devices">
-                            @foreach(auth()->user()->devices as $device)
-                                <flux:checkbox label="{{ $device->name }}" value="{{ $device->id }}"/>
+                            @foreach($this->manageableDevices as $device)
+                                <flux:checkbox
+                                    label="{{ $device->name }}{{ $device->user_id === null ? ' (shared)' : '' }}"
+                                    value="{{ $device->id }}"
+                                />
                             @endforeach
                         </flux:checkbox.group>
                     </div>
@@ -927,7 +945,7 @@ HTML;
                         <div class="mt-4 mb-4 space-y-6">
                             @foreach($checked_devices as $deviceId)
                                 @php
-                                    $device = auth()->user()->devices->find($deviceId);
+                                    $device = $this->manageableDevices->find($deviceId);
                                 @endphp
                                 <div class="border border-zinc-200 dark:border-zinc-700 rounded-lg p-4">
                                     <div class="text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-3">

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -538,6 +538,14 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
+
+            if ($this->transform_run_output !== null) {
+                $decoded = json_decode($this->transform_run_output, true);
+                if (is_array($decoded)) {
+                    $this->plugin->data_payload = $decoded;
+                }
+            }
+
             $previewMarkup = $this->plugin->render($size, true, $device);
             $dimensions = $this->previewScreenDimensionsForDevice($device);
             $this->dispatch(
@@ -596,6 +604,14 @@ HTML;
 
         try {
             $device = $this->createPreviewDevice();
+
+            if ($this->transform_run_output !== null) {
+                $decoded = json_decode($this->transform_run_output, true);
+                if (is_array($decoded)) {
+                    $this->plugin->data_payload = $decoded;
+                }
+            }
+
             $markup = $this->plugin->render($this->preview_size, true, $device);
 
             $imageUuid = App\Services\ImageGenerationService::generateImageFromModel(

--- a/resources/views/pages/settings/admin/users.blade.php
+++ b/resources/views/pages/settings/admin/users.blade.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Models\User;
+use Flux\Flux;
+use Livewire\Component;
+
+new class extends Component
+{
+    public function mount(): void
+    {
+        abort_unless(auth()->user()->isAdmin(), 403);
+    }
+
+    public function confirmUser(int $userId): void
+    {
+        abort_unless(auth()->user()->isAdmin(), 403);
+
+        User::findOrFail($userId)->update(['confirmed_at' => now()]);
+
+        Flux::toast(variant: 'success', text: 'User confirmed.');
+    }
+
+    public function revokeUser(int $userId): void
+    {
+        abort_unless(auth()->user()->isAdmin(), 403);
+        abort_if($userId === auth()->id(), 403, 'Cannot revoke yourself.');
+
+        User::findOrFail($userId)->update(['confirmed_at' => null]);
+
+        Flux::toast(variant: 'success', text: 'User confirmation revoked.');
+    }
+
+    public function makeAdmin(int $userId): void
+    {
+        abort_unless(auth()->user()->isAdmin(), 403);
+
+        User::findOrFail($userId)->update(['is_admin' => true]);
+
+        Flux::toast(variant: 'success', text: 'User promoted to admin.');
+    }
+
+    public function revokeAdmin(int $userId): void
+    {
+        abort_unless(auth()->user()->isAdmin(), 403);
+        abort_if($userId === 1, 403, 'Cannot remove admin from the primary admin.');
+        abort_if($userId === auth()->id(), 403, 'Cannot remove your own admin status.');
+
+        User::findOrFail($userId)->update(['is_admin' => false]);
+
+        Flux::toast(variant: 'success', text: 'Admin status removed.');
+    }
+
+    public function deleteUser(int $userId): void
+    {
+        abort_unless(auth()->user()->isAdmin(), 403);
+        abort_if($userId === auth()->id(), 403, 'Cannot delete yourself.');
+        abort_if($userId === 1, 403, 'Cannot delete the primary admin.');
+
+        User::findOrFail($userId)->delete();
+
+        Flux::toast(variant: 'success', text: 'User deleted.');
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function with(): array
+    {
+        return [
+            'users' => User::orderBy('confirmed_at')->orderBy('created_at')->get(),
+        ];
+    }
+};
+?>
+
+<section class="w-full py-12">
+    <div class="mx-auto max-w-7xl sm:px-6 lg:px-8">
+        @include('partials.settings-heading')
+
+        <x-pages::settings.layout heading="User Management" subheading="Confirm accounts and manage admin access.">
+            <div class="space-y-4">
+                @foreach ($users as $user)
+                    <div class="flex items-center justify-between p-3 border border-zinc-200 dark:border-zinc-700 rounded-lg
+                                {{ $user->confirmed_at === null ? 'border-amber-400 dark:border-amber-500' : '' }}">
+                        <div>
+                            <div class="font-medium text-sm">{{ $user->name }}</div>
+                            <div class="text-xs text-zinc-500">{{ $user->email }}</div>
+                            <div class="flex gap-2 mt-1">
+                                @if ($user->confirmed_at === null)
+                                    <flux:badge color="amber" size="sm">Pending</flux:badge>
+                                @else
+                                    <flux:badge color="green" size="sm">Confirmed</flux:badge>
+                                @endif
+                                @if ($user->is_admin)
+                                    <flux:badge color="blue" size="sm">Admin</flux:badge>
+                                @endif
+                            </div>
+                        </div>
+                        <div class="flex gap-2">
+                            @if ($user->confirmed_at === null)
+                                <flux:button size="sm" variant="primary" wire:click="confirmUser({{ $user->id }})">
+                                    Confirm
+                                </flux:button>
+                            @else
+                                <flux:button size="sm" variant="ghost" wire:click="revokeUser({{ $user->id }})"
+                                             wire:confirm="Revoke confirmation? This will block the user's access."
+                                             :disabled="$user->id === auth()->id()">
+                                    Revoke
+                                </flux:button>
+                            @endif
+
+                            @if (! $user->is_admin)
+                                <flux:button size="sm" variant="ghost" wire:click="makeAdmin({{ $user->id }})">
+                                    Make Admin
+                                </flux:button>
+                            @elseif ($user->id !== 1 && $user->id !== auth()->id())
+                                <flux:button size="sm" variant="ghost" wire:click="revokeAdmin({{ $user->id }})"
+                                             wire:confirm="Remove admin status from {{ $user->name }}?">
+                                    Remove Admin
+                                </flux:button>
+                            @endif
+
+                            @if ($user->id !== auth()->id() && $user->id !== 1)
+                                <flux:button size="sm" variant="danger" wire:click="deleteUser({{ $user->id }})"
+                                             wire:confirm="Permanently delete {{ $user->name }}? This cannot be undone.">
+                                    Delete
+                                </flux:button>
+                            @endif
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </x-pages::settings.layout>
+    </div>
+</section>

--- a/resources/views/pages/settings/admin/users.blade.php
+++ b/resources/views/pages/settings/admin/users.blade.php
@@ -8,7 +8,7 @@ new class extends Component
 {
     public function mount(): void
     {
-        abort_unless(auth()->user()->isAdmin(), 403);
+        abort_unless(config('app.multi_user_mode') && auth()->user()->isAdmin(), 403);
     }
 
     public function confirmUser(int $userId): void

--- a/resources/views/pages/settings/api-tokens.blade.php
+++ b/resources/views/pages/settings/api-tokens.blade.php
@@ -117,8 +117,7 @@ new #[Title('API Tokens')] class extends Component {
 
             @if (count($tokens) > 0)
                 <section class="mt-8">
-                    <flux:heading>{{ __('Manage tokens') }}</flux:heading>
-                    <flux:subheading>You may delete any of your existing tokens if they are no longer needed.</flux:subheading>
+                    <flux:heading>{{ __('Active tokens') }}</flux:heading>
 
                     <div class="mt-4 border rounded-lg border-zinc-200 dark:border-zinc-700 overflow-hidden">
                         @foreach ($tokens as $token)
@@ -173,12 +172,25 @@ new #[Title('API Tokens')] class extends Component {
                     </flux:text>
                 </div>
 
-                <flux:input
-                    value="{{ $newTokenValue }}"
-                    readonly
-                    copyable
-                    class="font-mono text-sm"
-                />
+                <div
+                    x-data="{ copied: false }"
+                    class="flex items-center gap-2"
+                >
+                    <flux:input
+                        value="{{ $newTokenValue }}"
+                        readonly
+                        class="font-mono text-sm"
+                        x-ref="tokenInput"
+                    />
+                    <flux:button
+                        variant="outline"
+                        size="sm"
+                        x-on:click="navigator.clipboard.writeText($refs.tokenInput.value); copied = true; setTimeout(() => copied = false, 2000)"
+                    >
+                        <span x-show="!copied">{{ __('Copy') }}</span>
+                        <span x-show="copied">{{ __('Copied!') }}</span>
+                    </flux:button>
+                </div>
 
                 <div class="flex justify-end">
                     <flux:button variant="primary" wire:click="closeNewTokenModal">

--- a/resources/views/pages/settings/layout.blade.php
+++ b/resources/views/pages/settings/layout.blade.php
@@ -19,6 +19,12 @@
             <flux:navlist.group :heading="__('Support')" class="mt-2">
                  <flux:navlist.item :href="route('settings.support')" wire:navigate>{{ __('Support & Referral') }}</flux:navlist.item>
             </flux:navlist.group>
+
+            @if (auth()?->user()?->isAdmin())
+                <flux:navlist.group :heading="__('Admin')" class="mt-2">
+                    <flux:navlist.item :href="route('settings.admin.users')" wire:navigate>{{ __('Users') }}</flux:navlist.item>
+                </flux:navlist.group>
+            @endif
         </flux:navlist>
     </div>
 

--- a/resources/views/pages/settings/layout.blade.php
+++ b/resources/views/pages/settings/layout.blade.php
@@ -20,7 +20,7 @@
                  <flux:navlist.item :href="route('settings.support')" wire:navigate>{{ __('Support & Referral') }}</flux:navlist.item>
             </flux:navlist.group>
 
-            @if (auth()?->user()?->isAdmin())
+            @if (config('app.multi_user_mode') && auth()?->user()?->isAdmin())
                 <flux:navlist.group :heading="__('Admin')" class="mt-2">
                     <flux:navlist.item :href="route('settings.admin.users')" wire:navigate>{{ __('Users') }}</flux:navlist.item>
                 </flux:navlist.group>

--- a/resources/views/pages/settings/layout.blade.php
+++ b/resources/views/pages/settings/layout.blade.php
@@ -8,7 +8,7 @@
                 <flux:navlist.item :href="route('security.edit')" wire:navigate>{{ __('Password & 2FA') }}</flux:navlist.item>
             @endif
             <flux:navlist.item :href="route('settings.api-tokens')" wire:navigate>{{ __('API Tokens') }}</flux:navlist.item>
-            @if (config('app.version'))
+            @if (config('app.version') && !config('app.docker'))
                 <flux:navlist.item :href="route('settings.update')" wire:navigate>{{ __('Updates') }}</flux:navlist.item>
             @endif
 

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,7 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 
-Route::middleware(['auth'])->group(function (): void {
+Route::middleware(['auth', 'confirmed'])->group(function (): void {
     Route::redirect('settings', 'settings/profile');
     Route::livewire('settings/preferences', 'pages::settings.preferences')->name('settings.preferences');
     Route::livewire('settings/profile', 'pages::settings.profile')->name('profile.edit');
@@ -14,7 +14,7 @@ Route::middleware(['auth'])->group(function (): void {
     Route::livewire('settings/update', 'pages::settings.update')->name('settings.update');
 });
 
-Route::middleware(['auth', 'verified'])->group(function (): void {
+Route::middleware(['auth', 'confirmed', 'verified'])->group(function (): void {
     Route::livewire('settings/appearance', 'pages::settings.appearance')->name('appearance.edit');
 
     Route::livewire('settings/security', 'pages::settings.security')

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -12,6 +12,7 @@ Route::middleware(['auth', 'confirmed'])->group(function (): void {
     Route::livewire('settings/api-tokens', 'pages::settings.api-tokens')->name('settings.api-tokens');
     Route::livewire('settings/lab', 'pages::settings.lab')->name('settings.lab');
     Route::livewire('settings/update', 'pages::settings.update')->name('settings.update');
+    Route::livewire('settings/admin/users', 'pages::settings.admin.users')->name('settings.admin.users');
 });
 
 Route::middleware(['auth', 'confirmed', 'verified'])->group(function (): void {

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,7 +8,7 @@ Route::get('/', function () {
     return view('welcome');
 })->name('home');
 
-Route::middleware(['auth'])->group(function () {
+Route::middleware(['auth', 'confirmed'])->group(function () {
 
     Route::livewire('/dashboard', 'device-dashboard')->name('dashboard');
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,21 @@
+{
+  pkgs ? import <nixpkgs> { config.allowUnfree = true; },
+}:
+let
+  php = pkgs.php84.buildEnv {
+    extensions = { enabled, all }: enabled ++ (with all; [ imagick ]);
+    extraConfig = "memory_limit=-1";
+  };
+in
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    php
+    php.packages.composer
+
+    nodejs_24
+    ruby_4_0
+
+    claude-code
+    bubblewrap
+  ];
+}

--- a/tests/Feature/AdminMigrationsTest.php
+++ b/tests/Feature/AdminMigrationsTest.php
@@ -1,0 +1,14 @@
+<?php
+// tests/Feature/AdminMigrationsTest.php
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+
+it('users table has is_admin and confirmed_at columns', function (): void {
+    expect(Schema::hasColumn('users', 'is_admin'))->toBeTrue();
+    expect(Schema::hasColumn('users', 'confirmed_at'))->toBeTrue();
+});
+
+it('plugins table has is_shared column', function (): void {
+    expect(Schema::hasColumn('plugins', 'is_shared'))->toBeTrue();
+});

--- a/tests/Feature/AdminUserManagementTest.php
+++ b/tests/Feature/AdminUserManagementTest.php
@@ -1,0 +1,131 @@
+<?php
+// tests/Feature/AdminUserManagementTest.php
+declare(strict_types=1);
+
+use App\Models\User;
+use Livewire\Livewire;
+
+it('non-admin cannot access admin users page', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1 (auto-admin)
+    $user = User::factory()->confirmed()->create();
+
+    $this->actingAs($user)
+        ->get(route('settings.admin.users'))
+        ->assertForbidden();
+});
+
+it('admin can access admin users page', function (): void {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->get(route('settings.admin.users'))
+        ->assertOk();
+});
+
+it('admin can confirm a user via Livewire action', function (): void {
+    $admin = User::factory()->admin()->create();
+    $pending = User::factory()->unconfirmed()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('confirmUser', $pending->id)
+        ->assertHasNoErrors();
+
+    expect($pending->fresh()->confirmed_at)->not->toBeNull();
+});
+
+it('admin can revoke a user confirmation via Livewire action', function (): void {
+    $admin = User::factory()->admin()->create();
+    $user = User::factory()->confirmed()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('revokeUser', $user->id)
+        ->assertHasNoErrors();
+
+    expect($user->fresh()->confirmed_at)->toBeNull();
+});
+
+it('admin cannot revoke their own confirmation', function (): void {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('revokeUser', $admin->id)
+        ->assertForbidden();
+});
+
+it('admin can promote a user to admin', function (): void {
+    $admin = User::factory()->admin()->create();
+    $user = User::factory()->confirmed()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('makeAdmin', $user->id)
+        ->assertHasNoErrors();
+
+    expect($user->fresh()->is_admin)->toBeTrue();
+});
+
+it('admin can revoke admin from another admin', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $admin = User::factory()->admin()->create();
+    $otherAdmin = User::factory()->admin()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('revokeAdmin', $otherAdmin->id)
+        ->assertHasNoErrors();
+
+    expect($otherAdmin->fresh()->is_admin)->toBeFalse();
+});
+
+it('admin cannot revoke their own admin status', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('revokeAdmin', $admin->id)
+        ->assertForbidden();
+});
+
+it('admin can delete another user', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $admin = User::factory()->admin()->create();
+    $user = User::factory()->confirmed()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('deleteUser', $user->id)
+        ->assertHasNoErrors();
+
+    expect($user->fresh())->toBeNull();
+});
+
+it('admin cannot delete themselves', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin);
+
+    Livewire::test('pages::settings.admin.users')
+        ->call('deleteUser', $admin->id)
+        ->assertForbidden();
+});
+
+it('non-admin is blocked from admin users page at route level', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $user = User::factory()->confirmed()->create();
+
+    $this->actingAs($user)
+        ->get(route('settings.admin.users'))
+        ->assertForbidden();
+});

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -134,7 +134,7 @@ test('new device is auto-assigned to user with auto-assign enabled', function ()
     $device = Device::where('mac_address', '00:11:22:33:44:55')->first();
     expect($device)
         ->not->toBeNull()
-        ->user_id->toBe($user->id)
+        ->user_id->toBeNull()
         ->api_key->toBe('new-device-key');
 });
 
@@ -167,7 +167,7 @@ test('new device is auto-assigned and mirrors specified device', function (): vo
     $newDevice = Device::where('mac_address', '00:11:22:33:44:55')->first();
     expect($newDevice)
         ->not->toBeNull()
-        ->user_id->toBe($user->id)
+        ->user_id->toBeNull()
         ->api_key->toBe('new-device-key')
         ->mirror_device_id->toBe($sourceDevice->id);
 

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -418,6 +418,7 @@ test('authenticated user can fetch device status', function (): void {
 });
 
 test('user cannot fetch status for devices they do not own', function (): void {
+    User::factory()->create(); // consume id=1 (auto-admin slot)
     $user = User::factory()->create();
     $otherUser = User::factory()->create();
     $device = Device::factory()->create(['user_id' => $otherUser->id]);

--- a/tests/Feature/ConfirmationGateTest.php
+++ b/tests/Feature/ConfirmationGateTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+it('unconfirmed user is redirected from dashboard to login', function (): void {
+    $user = User::factory()->unconfirmed()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertRedirect(route('login'));
+});
+
+it('unconfirmed user sees awaiting approval message', function (): void {
+    $user = User::factory()->unconfirmed()->create();
+
+    $response = $this->actingAs($user)->get(route('dashboard'));
+
+    $response->assertSessionHas('status', 'Your account is awaiting admin approval.');
+});
+
+it('confirmed user can access dashboard', function (): void {
+    $user = User::factory()->confirmed()->create();
+
+    $this->actingAs($user)
+        ->get(route('dashboard'))
+        ->assertOk();
+});
+
+it('unconfirmed user session is terminated on redirect', function (): void {
+    $user = User::factory()->unconfirmed()->create();
+
+    $this->actingAs($user)->get(route('dashboard'));
+
+    $this->assertGuest();
+});

--- a/tests/Feature/DeviceAutoJoinTest.php
+++ b/tests/Feature/DeviceAutoJoinTest.php
@@ -1,0 +1,36 @@
+<?php
+// tests/Feature/DeviceAutoJoinTest.php
+declare(strict_types=1);
+
+use App\Actions\Api\ResolveDeviceByApiKey;
+use App\Actions\Api\ResolveDeviceByMacAddress;
+use App\Models\Device;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+it('auto-join via api key creates device with null user_id', function (): void {
+    $user = User::factory()->confirmed()->create(['assign_new_devices' => true]);
+
+    $request = Request::create('/', 'GET', [], [], [], [
+        'HTTP_ACCESS-TOKEN' => 'new-token-123',
+        'HTTP_ID' => 'AA:BB:CC:DD:EE:FF',
+    ]);
+
+    $device = app(ResolveDeviceByApiKey::class)->handle($request, autoAssign: true);
+
+    expect($device)->not->toBeNull();
+    expect($device->user_id)->toBeNull();
+});
+
+it('auto-join via mac address creates device with null user_id', function (): void {
+    $user = User::factory()->confirmed()->create(['assign_new_devices' => true]);
+
+    $request = Request::create('/', 'GET', [], [], [], [
+        'HTTP_ID' => '11:22:33:44:55:66',
+    ]);
+
+    $device = app(ResolveDeviceByMacAddress::class)->handle($request);
+
+    expect($device)->not->toBeNull();
+    expect($device->user_id)->toBeNull();
+});

--- a/tests/Feature/DeviceManageAdminTest.php
+++ b/tests/Feature/DeviceManageAdminTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Device;
+use App\Models\User;
+
+// Burn id=1 so no test-created user is treated as admin by the id===1 shortcut
+beforeEach(function (): void {
+    User::factory()->create(); // id=1 burn user
+});
+
+it('regular user sees their own devices and unowned devices', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $ownDevice = Device::factory()->create(['user_id' => $user->id]);
+    $unownedDevice = Device::factory()->create(['user_id' => null]);
+    $otherDevice = Device::factory()->create(['user_id' => User::factory()->confirmed()->create()->id]);
+
+    $this->actingAs($user);
+    Livewire::test('devices.manage')
+        ->assertSee($ownDevice->name)
+        ->assertSee($unownedDevice->name)
+        ->assertDontSee($otherDevice->name);
+});
+
+it('admin can toggle show-all to see all devices', function (): void {
+    $admin = User::factory()->admin()->create();
+    $otherUser = User::factory()->confirmed()->create();
+    $otherDevice = Device::factory()->create(['user_id' => $otherUser->id]);
+
+    $this->actingAs($admin);
+    Livewire::test('devices.manage')
+        ->set('showAllDevices', true)
+        ->assertSee($otherDevice->name);
+});
+
+it('admin can reassign a device', function (): void {
+    $admin = User::factory()->admin()->create();
+    $user = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => null]);
+
+    $this->actingAs($admin);
+    Livewire::test('devices.manage')
+        ->call('reassignDevice', $device->id, $user->id)
+        ->assertHasNoErrors();
+
+    expect($device->fresh()->user_id)->toBe($user->id);
+});
+
+it('regular user cannot reassign a device', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => null]);
+
+    $this->actingAs($user);
+    Livewire::test('devices.manage')
+        ->call('reassignDevice', $device->id, $user->id)
+        ->assertForbidden();
+});

--- a/tests/Feature/DeviceManageAdminTest.php
+++ b/tests/Feature/DeviceManageAdminTest.php
@@ -40,8 +40,8 @@ it('admin can reassign a device', function (): void {
     $device = Device::factory()->create(['user_id' => null]);
 
     $this->actingAs($admin);
-    Livewire::test('devices.manage')
-        ->call('reassignDevice', $device->id, $user->id)
+    Livewire::test('devices.configure', ['device' => $device])
+        ->call('reassignDevice', $user->id)
         ->assertHasNoErrors();
 
     expect($device->fresh()->user_id)->toBe($user->id);
@@ -49,10 +49,11 @@ it('admin can reassign a device', function (): void {
 
 it('regular user cannot reassign a device', function (): void {
     $user = User::factory()->confirmed()->create();
-    $device = Device::factory()->create(['user_id' => null]);
+    $otherUser = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $user->id]);
 
     $this->actingAs($user);
-    Livewire::test('devices.manage')
-        ->call('reassignDevice', $device->id, $user->id)
+    Livewire::test('devices.configure', ['device' => $device])
+        ->call('reassignDevice', $otherUser->id)
         ->assertForbidden();
 });

--- a/tests/Feature/DevicePolicyTest.php
+++ b/tests/Feature/DevicePolicyTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Device;
+use App\Models\User;
+
+it('owner can view their device', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $user->id]);
+
+    expect($user->can('view', $device))->toBeTrue();
+});
+
+it('other user cannot view a private device', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $owner->id]);
+
+    expect($other->can('view', $device))->toBeFalse();
+});
+
+it('any user can view an unowned device', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => null]);
+
+    expect($user->can('view', $device))->toBeTrue();
+});
+
+it('admin can view any device', function (): void {
+    $admin = User::factory()->admin()->create();
+    $owner = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $owner->id]);
+
+    expect($admin->can('view', $device))->toBeTrue();
+});
+
+it('owner can update their device', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $user->id]);
+
+    expect($user->can('update', $device))->toBeTrue();
+});
+
+it('non-owner cannot update another user device', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $owner->id]);
+
+    expect($other->can('update', $device))->toBeFalse();
+});
+
+it('regular user can update an unowned device', function (): void {
+    User::factory()->create(); // consume id=1 (auto-admin slot)
+    $user = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => null]);
+
+    expect($user->can('update', $device))->toBeTrue();
+});
+
+it('admin can update unowned device', function (): void {
+    $admin = User::factory()->admin()->create();
+    $device = Device::factory()->create(['user_id' => null]);
+
+    expect($admin->can('update', $device))->toBeTrue();
+});
+
+it('only admin can reassign a device', function (): void {
+    $admin = User::factory()->admin()->create();
+    $user = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $user->id]);
+
+    expect($admin->can('reassign', $device))->toBeTrue();
+    expect($user->can('reassign', $device))->toBeFalse();
+});
+
+it('api returns 403 when non-owner requests device status', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $device = Device::factory()->create(['user_id' => $owner->id]);
+    $token = $other->createToken('test', ['update-screen'])->plainTextToken;
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->getJson("/api/display/status?device_id={$device->id}")
+        ->assertStatus(403);
+});

--- a/tests/Feature/Livewire/Actions/DeviceAutoJoinTest.php
+++ b/tests/Feature/Livewire/Actions/DeviceAutoJoinTest.php
@@ -15,33 +15,41 @@ test('device auto join component can be rendered', function (): void {
     Livewire::actingAs($user)
         ->test(DeviceAutoJoin::class)
         ->assertSee('Permit Auto-Join')
-        ->assertSet('deviceAutojoin', false)
-        ->assertSet('isFirstUser', true);
+        ->assertSet('deviceAutojoin', false);
 });
 
-test('device auto join component initializes with user settings', function (): void {
-    $user = User::factory()->create(['assign_new_devices' => true]);
+test('device auto join reflects global state: on when any user has it enabled', function (): void {
+    $userA = User::factory()->create(['assign_new_devices' => true]);
+    $userB = User::factory()->create(['assign_new_devices' => false]);
 
-    Livewire::actingAs($user)
+    Livewire::actingAs($userB)
         ->test(DeviceAutoJoin::class)
-        ->assertSet('deviceAutojoin', true)
-        ->assertSet('isFirstUser', true);
+        ->assertSet('deviceAutojoin', true);
 });
 
-test('device auto join component identifies first user correctly', function (): void {
+test('device auto join reflects global state: off when no user has it enabled', function (): void {
+    $userA = User::factory()->create(['assign_new_devices' => false]);
+    $userB = User::factory()->create(['assign_new_devices' => false]);
+
+    Livewire::actingAs($userB)
+        ->test(DeviceAutoJoin::class)
+        ->assertSet('deviceAutojoin', false);
+});
+
+test('device auto join component is visible to all confirmed users', function (): void {
     $firstUser = User::factory()->create(['id' => 1, 'assign_new_devices' => false]);
     $otherUser = User::factory()->create(['id' => 2, 'assign_new_devices' => false]);
 
     Livewire::actingAs($firstUser)
         ->test(DeviceAutoJoin::class)
-        ->assertSet('isFirstUser', true);
+        ->assertSee('Permit Auto-Join');
 
     Livewire::actingAs($otherUser)
         ->test(DeviceAutoJoin::class)
-        ->assertSet('isFirstUser', false);
+        ->assertSee('Permit Auto-Join');
 });
 
-test('device auto join component updates user setting when toggled', function (): void {
+test('turning on sets current user assign_new_devices', function (): void {
     $user = User::factory()->create(['assign_new_devices' => false]);
 
     Livewire::actingAs($user)
@@ -49,35 +57,20 @@ test('device auto join component updates user setting when toggled', function ()
         ->set('deviceAutojoin', true)
         ->assertSet('deviceAutojoin', true);
 
-    $user->refresh();
-    expect($user->assign_new_devices)->toBeTrue();
+    expect($user->fresh()->assign_new_devices)->toBeTrue();
 });
 
-// Validation test removed - Livewire automatically handles boolean conversion
+test('turning off clears assign_new_devices for all users', function (): void {
+    $userA = User::factory()->create(['assign_new_devices' => true]);
+    $userB = User::factory()->create(['assign_new_devices' => true]);
 
-test('device auto join component handles false value correctly', function (): void {
-    $user = User::factory()->create(['assign_new_devices' => true]);
-
-    Livewire::actingAs($user)
+    Livewire::actingAs($userA)
         ->test(DeviceAutoJoin::class)
         ->set('deviceAutojoin', false)
         ->assertSet('deviceAutojoin', false);
 
-    $user->refresh();
-    expect($user->assign_new_devices)->toBeFalse();
-});
-
-test('device auto join component only updates when deviceAutojoin property changes', function (): void {
-    $user = User::factory()->create(['assign_new_devices' => false]);
-
-    $component = Livewire::actingAs($user)
-        ->test(DeviceAutoJoin::class);
-
-    // Set a different property to ensure it doesn't trigger the update
-    $component->set('isFirstUser', true);
-
-    $user->refresh();
-    expect($user->assign_new_devices)->toBeFalse();
+    expect($userA->fresh()->assign_new_devices)->toBeFalse();
+    expect($userB->fresh()->assign_new_devices)->toBeFalse();
 });
 
 test('device auto join component renders correct view', function (): void {
@@ -88,16 +81,6 @@ test('device auto join component renders correct view', function (): void {
         ->assertViewIs('livewire.actions.device-auto-join');
 });
 
-test('device auto join component works with authenticated user', function (): void {
-    $user = User::factory()->create(['assign_new_devices' => true]);
-
-    $component = Livewire::actingAs($user)
-        ->test(DeviceAutoJoin::class);
-
-    expect($component->instance()->deviceAutojoin)->toBeTrue();
-    expect($component->instance()->isFirstUser)->toBe($user->id === 1);
-});
-
 test('device auto join component handles multiple updates correctly', function (): void {
     $user = User::factory()->create(['assign_new_devices' => false]);
 
@@ -105,11 +88,9 @@ test('device auto join component handles multiple updates correctly', function (
         ->test(DeviceAutoJoin::class)
         ->set('deviceAutojoin', true);
 
-    $user->refresh();
-    expect($user->assign_new_devices)->toBeTrue();
+    expect($user->fresh()->assign_new_devices)->toBeTrue();
 
     $component->set('deviceAutojoin', false);
 
-    $user->refresh();
-    expect($user->assign_new_devices)->toBeFalse();
+    expect($user->fresh()->assign_new_devices)->toBeFalse();
 });

--- a/tests/Feature/PluginArchiveTest.php
+++ b/tests/Feature/PluginArchiveTest.php
@@ -204,7 +204,8 @@ it('api route returns 401 for unauthenticated user', function (): void {
     $response->assertStatus(401);
 });
 
-it('api route returns 404 for plugin belonging to different user', function (): void {
+it('api route returns 403 for plugin belonging to different user', function (): void {
+    User::factory()->create(); // consume id=1 (auto-admin)
     $user1 = User::factory()->create();
     $user2 = User::factory()->create();
     $plugin = Plugin::factory()->create([
@@ -215,7 +216,7 @@ it('api route returns 404 for plugin belonging to different user', function (): 
     $response = $this->actingAs($user2)
         ->getJson("/api/plugin_settings/{$plugin->trmnlp_id}/archive");
 
-    $response->assertStatus(404);
+    $response->assertStatus(403);
 });
 
 it('exports render_markup_view blade file as full.blade.php', function (): void {

--- a/tests/Feature/PluginImportTest.php
+++ b/tests/Feature/PluginImportTest.php
@@ -697,6 +697,22 @@ it('sets both transform fields to null when serverless_language is absent even i
         ->and($plugin->transform_language)->toBeNull();
 });
 
+it('imports transform code from a flat-root ZIP (no src/ prefix, as trmnlp push produces)', function (): void {
+    $user = User::factory()->create();
+    $transformCode = "def run(input):\n    return {'count': len(input.get('data', []))}";
+
+    $zip = makeRootPluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: python\n",
+        'full.liquid'  => '<div>{{ count }}</div>',
+        'transform.py' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('python');
+});
+
 // Helper methods
 function createMockZipFile(array $files): string
 {
@@ -748,6 +764,19 @@ function makePluginZip(array $srcFiles): UploadedFile
     $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
     foreach ($srcFiles as $name => $content) {
         $zip->addFromString('src/'.$name, $content);
+    }
+    $zip->close();
+
+    return new UploadedFile($path, 'plugin.zip', 'application/zip', null, true);
+}
+
+function makeRootPluginZip(array $files): UploadedFile
+{
+    $path = tempnam(sys_get_temp_dir(), 'plugin-test-').'.zip';
+    $zip = new ZipArchive();
+    $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    foreach ($files as $name => $content) {
+        $zip->addFromString($name, $content);
     }
     $zip->close();
 

--- a/tests/Feature/PluginImportTest.php
+++ b/tests/Feature/PluginImportTest.php
@@ -620,6 +620,83 @@ it('imports plugin with only shared.blade.php file', function (): void {
         ->and($plugin->render_markup)->toBeNull();
 });
 
+it('imports transform_code and transform_language from a ZIP with a Python transform', function (): void {
+    $user = User::factory()->create();
+    $transformCode = "def run(input):\n    return {'count': len(input.get('data', []))}";
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: python\n",
+        'full.liquid'  => '<div>{{ count }}</div>',
+        'transform.py' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('python');
+});
+
+it('imports transform_code and transform_language from a ZIP with a Node transform', function (): void {
+    $user = User::factory()->create();
+    $transformCode = 'function run(input) { return { count: input.data.length }; }';
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: node\n",
+        'full.liquid'  => '<div>{{ count }}</div>',
+        'transform.js' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('node');
+});
+
+it('imports transform_code and transform_language from a ZIP with a PHP transform', function (): void {
+    $user = User::factory()->create();
+    $transformCode = '<?php function run($input) { return ["count" => count($input["data"] ?? [])]; }';
+
+    $zip = makePluginZip([
+        'settings.yml'  => "name: Test Plugin\nstrategy: polling\npolling_url: https://example.com\nserverless_language: php\n",
+        'full.liquid'   => '<div>{{ count }}</div>',
+        'transform.php' => $transformCode,
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBe($transformCode)
+        ->and($plugin->transform_language)->toBe('php');
+});
+
+it('sets both transform fields to null when no transform file is present', function (): void {
+    $user = User::factory()->create();
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: static\n",
+        'full.liquid'  => '<div>hello</div>',
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBeNull()
+        ->and($plugin->transform_language)->toBeNull();
+});
+
+it('sets both transform fields to null when serverless_language is absent even if a transform file is present', function (): void {
+    $user = User::factory()->create();
+
+    $zip = makePluginZip([
+        'settings.yml' => "name: Test Plugin\nstrategy: static\n",
+        'full.liquid'  => '<div>hello</div>',
+        'transform.py' => 'def run(input): return input',
+    ]);
+
+    $plugin = (new PluginImportService())->importFromZip($zip, $user);
+
+    expect($plugin->transform_code)->toBeNull()
+        ->and($plugin->transform_language)->toBeNull();
+});
+
 // Helper methods
 function createMockZipFile(array $files): string
 {
@@ -662,4 +739,17 @@ function getValidFullLiquid(): string
   <p>{{ data.description }}</p>
 </div>
 LIQUID;
+}
+
+function makePluginZip(array $srcFiles): UploadedFile
+{
+    $path = tempnam(sys_get_temp_dir(), 'plugin-test-').'.zip';
+    $zip = new ZipArchive();
+    $zip->open($path, ZipArchive::CREATE | ZipArchive::OVERWRITE);
+    foreach ($srcFiles as $name => $content) {
+        $zip->addFromString('src/'.$name, $content);
+    }
+    $zip->close();
+
+    return new UploadedFile($path, 'plugin.zip', 'application/zip', null, true);
 }

--- a/tests/Feature/PluginIndexAdminTest.php
+++ b/tests/Feature/PluginIndexAdminTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Plugin;
+use App\Models\User;
+
+it('owner can toggle plugin sharing', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $user = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $user->id, 'is_shared' => false, 'plugin_type' => 'recipe']);
+
+    $this->actingAs($user);
+    Livewire::test('plugins.index')
+        ->call('toggleShared', $plugin->id)
+        ->assertHasNoErrors();
+
+    expect($plugin->fresh()->is_shared)->toBeTrue();
+});
+
+it('non-owner cannot toggle plugin sharing', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => false, 'plugin_type' => 'recipe']);
+
+    $this->actingAs($other);
+    Livewire::test('plugins.index')
+        ->call('toggleShared', $plugin->id)
+        ->assertForbidden();
+});
+
+it('user can copy a shared plugin', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $owner = User::factory()->confirmed()->create();
+    $copier = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create([
+        'user_id' => $owner->id,
+        'is_shared' => true,
+        'plugin_type' => 'recipe',
+        'name' => 'Shared Plugin',
+    ]);
+
+    $this->actingAs($copier);
+    Livewire::test('plugins.index')
+        ->call('copyPlugin', $plugin->id)
+        ->assertHasNoErrors();
+
+    expect(Plugin::where('user_id', $copier->id)->where('name', 'Shared Plugin')->exists())->toBeTrue();
+});
+
+it('cannot copy a private plugin', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => false, 'plugin_type' => 'recipe']);
+
+    $this->actingAs($other);
+    Livewire::test('plugins.index')
+        ->call('copyPlugin', $plugin->id)
+        ->assertForbidden();
+});
+
+it('admin can reassign plugin ownership', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1
+    $admin = User::factory()->admin()->create();
+    $owner = User::factory()->confirmed()->create();
+    $newOwner = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'plugin_type' => 'recipe']);
+
+    $this->actingAs($admin);
+    Livewire::test('plugins.recipe', ['plugin' => $plugin])
+        ->call('reassignPlugin', $newOwner->id)
+        ->assertHasNoErrors();
+
+    expect($plugin->fresh()->user_id)->toBe($newOwner->id);
+});

--- a/tests/Feature/PluginPolicyTest.php
+++ b/tests/Feature/PluginPolicyTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Plugin;
+use App\Models\User;
+
+it('owner can view their private plugin', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $user->id, 'is_shared' => false]);
+
+    expect($user->can('view', $plugin))->toBeTrue();
+});
+
+it('non-owner cannot view private plugin', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => false]);
+
+    expect($other->can('view', $plugin))->toBeFalse();
+});
+
+it('any confirmed user can view shared plugin', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => true]);
+
+    expect($other->can('view', $plugin))->toBeTrue();
+});
+
+it('admin can view any plugin', function (): void {
+    $admin = User::factory()->admin()->create();
+    $owner = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => false]);
+
+    expect($admin->can('view', $plugin))->toBeTrue();
+});
+
+it('owner can update their plugin', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $user->id]);
+
+    expect($user->can('update', $plugin))->toBeTrue();
+});
+
+it('non-owner cannot update plugin', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id]);
+
+    expect($other->can('update', $plugin))->toBeFalse();
+});
+
+it('admin can update any plugin', function (): void {
+    $admin = User::factory()->admin()->create();
+    $owner = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id]);
+
+    expect($admin->can('update', $plugin))->toBeTrue();
+});
+
+it('only admin can reassign a plugin', function (): void {
+    $admin = User::factory()->admin()->create();
+    $user = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $user->id]);
+
+    expect($admin->can('reassign', $plugin))->toBeTrue();
+    expect($user->can('reassign', $plugin))->toBeFalse();
+});
+
+it('any confirmed user can copy a shared plugin', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => true]);
+
+    expect($other->can('copy', $plugin))->toBeTrue();
+});
+
+it('cannot copy a private plugin', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => false]);
+
+    expect($other->can('copy', $plugin))->toBeFalse();
+});
+
+it('api plugin settings index only returns own plugins', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $otherUser = User::factory()->confirmed()->create();
+    Plugin::factory()->create(['user_id' => $user->id, 'trmnlp_id' => 'own-plugin']);
+    Plugin::factory()->create(['user_id' => $otherUser->id, 'trmnlp_id' => 'other-plugin']);
+    $token = $user->createToken('test', ['update-screen'])->plainTextToken;
+
+    $response = $this->withHeader('Authorization', "Bearer {$token}")
+        ->getJson('/api/plugin_settings');
+
+    $ids = collect($response->json('data'))->pluck('id');
+    expect($ids)->toContain('own-plugin');
+    expect($ids)->not->toContain('other-plugin');
+});
+
+it('api plugin destroy denies non-owner', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1 (auto-admin)
+    $owner = User::factory()->confirmed()->create();
+    $other = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $owner->id, 'trmnlp_id' => 'target-plugin']);
+    $token = $other->createToken('test', ['update-screen'])->plainTextToken;
+
+    $this->withHeader('Authorization', "Bearer {$token}")
+        ->deleteJson('/api/plugin_settings/target-plugin')
+        ->assertStatus(403);
+});

--- a/tests/Feature/PluginVisibilityTest.php
+++ b/tests/Feature/PluginVisibilityTest.php
@@ -1,0 +1,45 @@
+<?php
+// tests/Feature/PluginVisibilityTest.php
+declare(strict_types=1);
+
+use App\Models\Plugin;
+use App\Models\User;
+
+it('scopeVisibleTo returns own plugins', function (): void {
+    $user = User::factory()->confirmed()->create();
+    $plugin = Plugin::factory()->create(['user_id' => $user->id, 'is_shared' => false]);
+
+    $results = Plugin::visibleTo($user)->pluck('id');
+
+    expect($results)->toContain($plugin->id);
+});
+
+it('scopeVisibleTo returns shared plugins from other users', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $viewer = User::factory()->confirmed()->create();
+    $sharedPlugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => true]);
+
+    $results = Plugin::visibleTo($viewer)->pluck('id');
+
+    expect($results)->toContain($sharedPlugin->id);
+});
+
+it('scopeVisibleTo hides non-shared plugins from other users', function (): void {
+    $owner = User::factory()->confirmed()->create();
+    $viewer = User::factory()->confirmed()->create();
+    $privatePlugin = Plugin::factory()->create(['user_id' => $owner->id, 'is_shared' => false]);
+
+    $results = Plugin::visibleTo($viewer)->pluck('id');
+
+    expect($results)->not->toContain($privatePlugin->id);
+});
+
+it('scopeVisibleTo returns all plugins for admins', function (): void {
+    $admin = User::factory()->admin()->create();
+    $otherUser = User::factory()->confirmed()->create();
+    $privatePlugin = Plugin::factory()->create(['user_id' => $otherUser->id, 'is_shared' => false]);
+
+    $results = Plugin::visibleTo($admin)->pluck('id');
+
+    expect($results)->toContain($privatePlugin->id);
+});

--- a/tests/Feature/RegistrationConfirmationTest.php
+++ b/tests/Feature/RegistrationConfirmationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\User;
+
+beforeEach(function (): void {
+    // Create an admin user first (ensures ID 1 exists before registration tests)
+    User::factory()->admin()->create([
+        'email' => 'admin@example.com',
+    ]);
+});
+
+it('newly registered user via Fortify is unconfirmed', function (): void {
+    $response = $this->post('/register', [
+        'name' => 'New User',
+        'email' => 'newuser@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $user = User::where('email', 'newuser@example.com')->first();
+    expect($user)->not->toBeNull();
+    expect($user->confirmed_at)->toBeNull();
+});
+
+it('newly registered user is immediately redirected away (unconfirmed)', function (): void {
+    $this->post('/register', [
+        'name' => 'New User',
+        'email' => 'newuser2@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ]);
+
+    $user = User::where('email', 'newuser2@example.com')->first();
+    $this->actingAs($user)->get(route('dashboard'))->assertRedirect(route('login'));
+});

--- a/tests/Feature/UserModelTest.php
+++ b/tests/Feature/UserModelTest.php
@@ -1,0 +1,36 @@
+<?php
+// tests/Feature/UserModelTest.php
+declare(strict_types=1);
+
+use App\Models\User;
+
+it('isAdmin returns true when is_admin is true', function (): void {
+    $user = User::factory()->admin()->create();
+    expect($user->isAdmin())->toBeTrue();
+});
+
+it('isAdmin returns false by default', function (): void {
+    $user = User::factory()->confirmed()->create();
+    expect($user->isAdmin())->toBeFalse();
+});
+
+it('isConfirmed returns true when confirmed_at is set', function (): void {
+    $user = User::factory()->confirmed()->create();
+    expect($user->isConfirmed())->toBeTrue();
+});
+
+it('isConfirmed returns false when confirmed_at is null', function (): void {
+    $user = User::factory()->unconfirmed()->create();
+    expect($user->isConfirmed())->toBeFalse();
+});
+
+it('user id 1 is always admin regardless of is_admin column', function (): void {
+    // Create first user (will get id=1 in a clean test DB)
+    $user = User::factory()->confirmed()->create(['is_admin' => false]);
+    if ($user->id === 1) {
+        $user->refresh();
+        expect($user->isAdmin())->toBeTrue();
+    } else {
+        expect(true)->toBeTrue(); // skip if not first user in this test run
+    }
+});

--- a/tests/Feature/UserModelTest.php
+++ b/tests/Feature/UserModelTest.php
@@ -10,6 +10,7 @@ it('isAdmin returns true when is_admin is true', function (): void {
 });
 
 it('isAdmin returns false by default', function (): void {
+    User::factory()->confirmed()->create(); // consume id=1 (auto-admin)
     $user = User::factory()->confirmed()->create();
     expect($user->isAdmin())->toBeFalse();
 });

--- a/tests/Unit/Models/PluginTest.php
+++ b/tests/Unit/Models/PluginTest.php
@@ -4,6 +4,7 @@ use App\Models\Playlist;
 use App\Models\PlaylistItem;
 use App\Models\Plugin;
 use App\Models\User;
+use App\Services\Plugin\ServerlessTransformService;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Http;
 
@@ -1079,4 +1080,65 @@ test('deleting plugin cascades mashup playlist items containing plugin id', func
     $secondaryPlugin->delete();
 
     expect(PlaylistItem::query()->find($mashupItem->id))->toBeNull();
+});
+
+test('updateDataPayload pipes polled data through the transform when both transform fields are set', function (): void {
+    Http::fake(['*' => Http::response(['id1', 'id2'], 200, ['Content-Type' => 'application/json'])]);
+
+    $this->mock(ServerlessTransformService::class)
+        ->shouldReceive('run')
+        ->once()
+        ->andReturn(['stories' => [['title' => 'Test Story']]]);
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy'      => 'polling',
+        'polling_url'        => 'https://example.com/api',
+        'polling_verb'       => 'get',
+        'transform_code'     => "def run(input):\n    return {'stories': []}",
+        'transform_language' => 'python',
+    ]);
+
+    $plugin->updateDataPayload();
+
+    expect($plugin->fresh()->data_payload)->toBe(['stories' => [['title' => 'Test Story']]]);
+});
+
+test('updateDataPayload skips the transform when transform_code is null', function (): void {
+    Http::fake(['*' => Http::response(['key' => 'value'], 200, ['Content-Type' => 'application/json'])]);
+
+    $this->mock(ServerlessTransformService::class)
+        ->shouldNotReceive('run');
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy'      => 'polling',
+        'polling_url'        => 'https://example.com/api',
+        'polling_verb'       => 'get',
+        'transform_code'     => null,
+        'transform_language' => null,
+    ]);
+
+    $plugin->updateDataPayload();
+
+    expect($plugin->fresh()->data_payload)->not->toBeNull();
+});
+
+test('updateDataPayload stores raw polled data when the transform service returns it unchanged', function (): void {
+    Http::fake(['*' => Http::response(['raw' => 'data'], 200, ['Content-Type' => 'application/json'])]);
+
+    $this->mock(ServerlessTransformService::class)
+        ->shouldReceive('run')
+        ->once()
+        ->andReturn(['raw' => 'data']);
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy'      => 'polling',
+        'polling_url'        => 'https://example.com/api',
+        'polling_verb'       => 'get',
+        'transform_code'     => 'bad code',
+        'transform_language' => 'php',
+    ]);
+
+    $plugin->updateDataPayload();
+
+    expect($plugin->fresh()->data_payload)->toBe(['raw' => 'data']);
 });

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -23,56 +23,51 @@ it('returns input unchanged when runner URL is not configured', function (): voi
     Http::assertNothingSent();
 });
 
-it('returns input unchanged when runner returns 422', function (): void {
+it('returns error payload when runner returns 422', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response(['error' => 'syntax error'], 422)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('bad code', 'php', $input);
+    $result = (new ServerlessTransformService())->run('bad code', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
-it('returns input unchanged when runner returns 500', function (): void {
+it('returns error payload when runner returns 500', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response([], 500)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+    $result = (new ServerlessTransformService())->run('...', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
-it('returns input unchanged when runner output is not an array', function (): void {
+it('returns runner body when runner output is not an array', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response(['output' => null], 200)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+    $result = (new ServerlessTransformService())->run('...', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toBe(['output' => null]);
 });
 
-it('returns input unchanged when connection fails', function (): void {
+it('returns error payload when connection fails', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => function () {
         throw new \Illuminate\Http\Client\ConnectionException('Connection refused');
     }]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+    $result = (new ServerlessTransformService())->run('...', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
-it('returns input unchanged when runner returns 400 for unsupported language', function (): void {
+it('returns error payload when runner returns 400 for unsupported language', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     Http::fake(['*/run' => Http::response(['error' => 'unsupported language'], 400)]);
 
-    $input = ['key' => 'value'];
-    $result = (new ServerlessTransformService())->run('<?php echo "x";', 'php', $input);
+    $result = (new ServerlessTransformService())->run('<?php echo "x";', 'php', ['key' => 'value']);
 
-    expect($result)->toBe($input);
+    expect($result)->toHaveKey('error');
 });
 
 it('isEnabled returns true when runner URL is configured', function (): void {

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -65,6 +65,16 @@ it('returns input unchanged when connection fails', function (): void {
     expect($result)->toBe($input);
 });
 
+it('returns input unchanged when runner returns 400 for unsupported language', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['error' => 'unsupported language'], 400)]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('<?php echo "x";', 'php', $input);
+
+    expect($result)->toBe($input);
+});
+
 it('isEnabled returns true when runner URL is configured', function (): void {
     config(['services.transform_runner.url' => 'http://runner:3000']);
     expect((new ServerlessTransformService())->isEnabled())->toBeTrue();

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -1,95 +1,76 @@
 <?php
 
 use App\Services\Plugin\ServerlessTransformService;
-use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Http;
 
-it('transforms data with a PHP run() function', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        'function run($input) { return ["doubled" => $input["value"] * 2]; }',
-        'php',
-        ['value' => 5]
-    );
+it('returns transformed output when runner responds with 200', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['output' => ['doubled' => 10]], 200)]);
+
+    $result = (new ServerlessTransformService())->run('...', 'php', ['value' => 5]);
+
     expect($result)->toBe(['doubled' => 10]);
 });
 
-it('strips a leading <?php tag from PHP user code', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        "<?php\nfunction run(\$input) { return ['ok' => true]; }",
-        'php',
-        []
-    );
-    expect($result)->toBe(['ok' => true]);
-});
+it('returns input unchanged when runner URL is not configured', function (): void {
+    config(['services.transform_runner.url' => null]);
+    Http::fake();
 
-it('falls back to $result variable when run() is not defined (PHP)', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run('$result = ["fallback" => true];', 'php', []);
-    expect($result)->toBe(['fallback' => true]);
-});
-
-it('passes input through unchanged when neither run() nor $result is defined (PHP)', function (): void {
-    $service = new ServerlessTransformService();
     $input = ['key' => 'value'];
-    expect($service->run('// no-op', 'php', $input))->toBe($input);
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
+    expect($result)->toBe($input);
+    Http::assertNothingSent();
 });
 
-it('transforms data with a Node run() function', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        'function run(input) { return { doubled: input.value * 2 }; }',
-        'node',
-        ['value' => 5]
-    );
-    expect($result)->toBe(['doubled' => 10]);
-});
+it('returns input unchanged when runner returns 422', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['error' => 'syntax error'], 422)]);
 
-it('falls back to result variable when run is not defined (Node)', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run('const result = { fallback: true };', 'node', []);
-    expect($result)->toBe(['fallback' => true]);
-});
-
-it('transforms data with a Python run() function', function (): void {
-    $service = new ServerlessTransformService();
-    $result = $service->run(
-        "def run(input):\n    return {'doubled': input['value'] * 2}",
-        'python',
-        ['value' => 5]
-    );
-    expect($result)->toBe(['doubled' => 10]);
-})->skip(fn () => empty(trim((string) shell_exec('which python3 2>/dev/null'))), 'python3 not on PATH');
-
-it('returns input unchanged for an unsupported language', function (): void {
-    $service = new ServerlessTransformService();
     $input = ['key' => 'value'];
-    expect($service->run('noop', 'cobol', $input))->toBe($input);
-});
+    $result = (new ServerlessTransformService())->run('bad code', 'php', $input);
 
-it('returns input unchanged when the transform exits non-zero', function (): void {
-    Process::fake(['*' => Process::result(output: '', errorOutput: 'fatal error', exitCode: 1)]);
-    $service = new ServerlessTransformService();
-    $input = ['key' => 'value'];
-    expect($service->run('function run($input) { return $input; }', 'php', $input))->toBe($input);
-});
-
-it('returns input unchanged when the transform output is not a JSON object', function (): void {
-    // run() returns null → json_encode(null) = "null" → json_decode → null, not array
-    $service = new ServerlessTransformService();
-    $input = ['key' => 'value'];
-    $result = $service->run('function run($input) { return null; }', 'php', $input);
     expect($result)->toBe($input);
 });
 
-it('returns input unchanged on timeout', function (): void {
-    $service = new ServerlessTransformService();
-    $input = ['value' => 1];
-    $result = $service->run(
-        '<?php function run($input) { sleep(10); return $input; }',
-        'php',
-        $input,
-        1  // 1-second timeout
-    );
+it('returns input unchanged when runner returns 500', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response([], 500)]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
     expect($result)->toBe($input);
+});
+
+it('returns input unchanged when runner output is not an array', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => Http::response(['output' => null], 200)]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
+    expect($result)->toBe($input);
+});
+
+it('returns input unchanged when connection fails', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    Http::fake(['*/run' => function () {
+        throw new \Illuminate\Http\Client\ConnectionException('Connection refused');
+    }]);
+
+    $input = ['key' => 'value'];
+    $result = (new ServerlessTransformService())->run('...', 'php', $input);
+
+    expect($result)->toBe($input);
+});
+
+it('isEnabled returns true when runner URL is configured', function (): void {
+    config(['services.transform_runner.url' => 'http://runner:3000']);
+    expect((new ServerlessTransformService())->isEnabled())->toBeTrue();
+});
+
+it('isEnabled returns false when runner URL is not configured', function (): void {
+    config(['services.transform_runner.url' => null]);
+    expect((new ServerlessTransformService())->isEnabled())->toBeFalse();
 });

--- a/tests/Unit/Services/ServerlessTransformServiceTest.php
+++ b/tests/Unit/Services/ServerlessTransformServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Services\Plugin\ServerlessTransformService;
+use Illuminate\Support\Facades\Process;
+
+it('transforms data with a PHP run() function', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        'function run($input) { return ["doubled" => $input["value"] * 2]; }',
+        'php',
+        ['value' => 5]
+    );
+    expect($result)->toBe(['doubled' => 10]);
+});
+
+it('strips a leading <?php tag from PHP user code', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        "<?php\nfunction run(\$input) { return ['ok' => true]; }",
+        'php',
+        []
+    );
+    expect($result)->toBe(['ok' => true]);
+});
+
+it('falls back to $result variable when run() is not defined (PHP)', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run('$result = ["fallback" => true];', 'php', []);
+    expect($result)->toBe(['fallback' => true]);
+});
+
+it('passes input through unchanged when neither run() nor $result is defined (PHP)', function (): void {
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    expect($service->run('// no-op', 'php', $input))->toBe($input);
+});
+
+it('transforms data with a Node run() function', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        'function run(input) { return { doubled: input.value * 2 }; }',
+        'node',
+        ['value' => 5]
+    );
+    expect($result)->toBe(['doubled' => 10]);
+});
+
+it('falls back to result variable when run is not defined (Node)', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run('const result = { fallback: true };', 'node', []);
+    expect($result)->toBe(['fallback' => true]);
+});
+
+it('transforms data with a Python run() function', function (): void {
+    $service = new ServerlessTransformService();
+    $result = $service->run(
+        "def run(input):\n    return {'doubled': input['value'] * 2}",
+        'python',
+        ['value' => 5]
+    );
+    expect($result)->toBe(['doubled' => 10]);
+})->skip(fn () => empty(trim((string) shell_exec('which python3 2>/dev/null'))), 'python3 not on PATH');
+
+it('returns input unchanged for an unsupported language', function (): void {
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    expect($service->run('noop', 'cobol', $input))->toBe($input);
+});
+
+it('returns input unchanged when the transform exits non-zero', function (): void {
+    Process::fake(['*' => Process::result(output: '', errorOutput: 'fatal error', exitCode: 1)]);
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    expect($service->run('function run($input) { return $input; }', 'php', $input))->toBe($input);
+});
+
+it('returns input unchanged when the transform output is not a JSON object', function (): void {
+    // run() returns null → json_encode(null) = "null" → json_decode → null, not array
+    $service = new ServerlessTransformService();
+    $input = ['key' => 'value'];
+    $result = $service->run('function run($input) { return null; }', 'php', $input);
+    expect($result)->toBe($input);
+});
+
+it('returns input unchanged on timeout', function (): void {
+    $service = new ServerlessTransformService();
+    $input = ['value' => 1];
+    $result = $service->run(
+        '<?php function run($input) { sleep(10); return $input; }',
+        'php',
+        $input,
+        1  // 1-second timeout
+    );
+    expect($result)->toBe($input);
+});


### PR DESCRIPTION
This PR reworks multi-user mode, adding the concept of admins and shared plugins. 

The unprivileged user can now use auto-join, devices joined this way are "unassigned" and can be edited by everyone. Admins can view other people's devices.

<img width="1257" height="215" alt="image" src="https://github.com/user-attachments/assets/91c9ab7e-c07c-4036-b7bb-dd3c560c179d" />

Registration stays open, but users can't do anything until they are confirmed by an admin. Admins can manage users and approve/revoke them.

<img width="857" height="568" alt="image" src="https://github.com/user-attachments/assets/c1e22fa1-71f0-41db-97ce-8f36d9841796" />

Plugins can be shared between users, then they can be copied to the user's account manually ("forked").

<img width="858" height="624" alt="image" src="https://github.com/user-attachments/assets/cfa4b741-5d5c-468c-a65a-6e528a9cc440" />

I agree to license this contribution as MIT. Supersedes #257