### PR TITLE
refactor: recipe edit UI

### DIFF
--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1316,20 +1316,6 @@ HTML;
 
                 </div>
             @else
-            <div class="flex items-center gap-6 mb-4 mt-4">
-                <div class="flex-1 flex items-center">
-                    <span class="pr-2">Template language</span>
-                    <flux:radio.group wire:model.live="markup_language" variant="segmented">
-                        <flux:radio value="blade" label="Blade"/>
-                        <flux:radio value="liquid" label="Liquid"/>
-                    </flux:radio.group>
-                </div>
-                <div class="text-accent flex items-center gap-2">
-                    <span class="pr-2">Getting started</span>
-                    <flux:button wire:click="renderExample('layoutTitle')" class="text-xl">Responsive Layout with Title Bar</flux:button>
-                    <flux:button wire:click="renderExample('layout')" class="text-xl">Responsive Layout</flux:button>
-                </div>
-            </div>
             @endif
         </div>
         @if(!$plugin->render_markup_view)
@@ -1410,6 +1396,21 @@ HTML;
                     <flux:button type="submit" variant="primary">
                         Save
                     </flux:button>
+                </div>
+
+                <div class="flex items-center gap-3 mt-4">
+                    <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Template language</span>
+                    <flux:select wire:model.live="markup_language" class="max-w-xs">
+                        <flux:select.option value="blade">Blade</flux:select.option>
+                        <flux:select.option value="liquid">Liquid</flux:select.option>
+                    </flux:select>
+                </div>
+
+                <div class="flex items-center gap-3 mt-3">
+                    <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Getting started</span>
+                    <flux:button size="sm" wire:click="renderExample('layoutTitle')">Responsive Layout with Title Bar</flux:button>
+                    <flux:button size="sm" wire:click="renderExample('layout')">Responsive Layout</flux:button>
+                    <span class="text-xs text-zinc-400 dark:text-zinc-500">These will replace the current template.</span>
                 </div>
             </form>
         @endif

--- a/resources/views/livewire/plugins/recipe.blade.php
+++ b/resources/views/livewire/plugins/recipe.blade.php
@@ -1093,8 +1093,17 @@ HTML;
                     @if($data_strategy === 'polling')
                     <flux:label>Polling URL</flux:label>
 
-                    <div x-data="{ subTab: 'settings' }" class="mt-2 mb-4">
+                    <div x-data="{ subTab: 'urls' }" class="mt-2 mb-4">
                         <div class="flex">
+                            <button
+                                @click="subTab = 'urls'"
+                                class="tab-button"
+                                :class="subTab === 'urls' ? 'is-active' : ''"
+                            >
+                                <flux:icon.link class="size-4"/>
+                                URLs
+                            </button>
+
                             <button
                                 @click="subTab = 'settings'"
                                 class="tab-button"
@@ -1103,19 +1112,11 @@ HTML;
                                 <flux:icon.cog-6-tooth class="size-4"/>
                                 Settings
                             </button>
-
-                            <button
-                                @click="subTab = 'preview'"
-                                class="tab-button"
-                                :class="subTab === 'preview' ? 'is-active' : ''"
-                            >
-                                <flux:icon.eye class="size-4" />
-                                Preview URL
-                            </button>
                         </div>
 
                         <div class="flex-col p-4 bg-transparent rounded-tl-none styled-container">
-                            <div x-show="subTab === 'settings'">
+                            {{-- URLs tab --}}
+                            <div x-show="subTab === 'urls'">
                                 <flux:field>
                                     <flux:description>Enter the URL(s) to poll for data:</flux:description>
                                     <flux:textarea
@@ -1127,63 +1128,67 @@ HTML;
                                         {!! 'Hint: Supports multiple requests via line break separation. You can also use configuration variables with <a href="https://help.usetrmnl.com/en/articles/12689499-dynamic-polling-urls">Liquid syntax</a>. ' !!}
                                     </flux:description>
                                 </flux:field>
+
+                                <div class="mt-3">
+                                    <flux:field>
+                                        <flux:description>Preview computed URLs here (readonly):</flux:description>
+                                        <flux:textarea
+                                            readonly
+                                            placeholder="Nothing to show..."
+                                            rows="3"
+                                        >
+                                            {{ $this->parsed_urls }}
+                                        </flux:textarea>
+                                    </flux:field>
+                                </div>
+
+                                <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
+                                    Fetch data now
+                                </flux:button>
                             </div>
 
-                            <div x-show="subTab === 'preview'" x-cloak>
-                                <flux:field>
-                                    <flux:description>Preview computed URLs here (readonly):</flux:description>
+                            {{-- Settings tab --}}
+                            <div x-show="subTab === 'settings'" x-cloak>
+                                <div class="mb-4">
+                                    <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
+                                        <flux:radio value="get" label="GET"/>
+                                        <flux:radio value="post" label="POST"/>
+                                    </flux:radio.group>
+                                </div>
+
+                                <div class="mb-4">
                                     <flux:textarea
-                                        readonly
-                                        placeholder="Nothing to show..."
-                                        rows="5"
-                                    >
-                                        {{ $this->parsed_urls }}
-                                    </flux:textarea>
-                                </flux:field>
-                            </div>
+                                        label="Polling Headers (one per line, format: Header: Value)"
+                                        wire:model="polling_header"
+                                        id="polling_header"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_header"
+                                        rows="3"
+                                        placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
+                                    />
+                                </div>
 
-                            <flux:button icon="cloud-arrow-down" wire:click="updateData" class="w-full mt-4">
-                                Fetch data now
-                            </flux:button>
+                                @if($polling_verb === 'post')
+                                <div class="mb-4">
+                                    <flux:textarea
+                                        label="Polling Body (e.g. for GraphQL queries)"
+                                        wire:model="polling_body"
+                                        id="polling_body"
+                                        class="block mt-1 w-full font-mono"
+                                        name="polling_body"
+                                        rows="6"
+                                    />
+                                </div>
+                                @endif
+
+                                <div class="mb-4">
+                                    <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
+                                                id="data_stale_minutes"
+                                                class="block mt-1 w-full" type="number" name="data_stale_minutes"/>
+                                </div>
+                            </div>
                         </div>
                     </div>
-
-                        <div class="mb-4">
-                            <flux:radio.group wire:model.live="polling_verb" label="Polling Verb" variant="segmented">
-                                <flux:radio value="get" label="GET"/>
-                                <flux:radio value="post" label="POST"/>
-                            </flux:radio.group>
-                        </div>
-
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Headers (one per line, format: Header: Value)"
-                                wire:model="polling_header"
-                                id="polling_header"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_header"
-                                rows="3"
-                                placeholder="Authorization: Bearer ey.*******&#10;Content-Type: application/json"
-                            />
-                        </div>
-
-                        @if($polling_verb === 'post')
-                        <div class="mb-4">
-                            <flux:textarea
-                                label="Polling Body (e.g. for GraphQL queries)"
-                                wire:model="polling_body"
-                                id="polling_body"
-                                class="block mt-1 w-full font-mono"
-                                name="polling_body"
-                                rows="6"
-                            />
-                        </div>
-                        @endif
-                        <div class="mb-4">
-                            <flux:input label="Data is stale after minutes" wire:model="data_stale_minutes"
-                                        id="data_stale_minutes"
-                                        class="block mt-1 w-full" type="number" name="data_stale_minutes" autofocus/>
-                        </div>
                     @elseif($data_strategy === 'webhook')
                         <div class="mb-4">
                             <flux:field>


### PR DESCRIPTION
- Move Getting started buttons below the Save button; make them size="sm"
- Add "These will replace the current template." note next to the buttons
- Move polling options into a card instead of below the URLs