### PR TITLE
Fix ical multiday events

### DIFF
--- a/app/Services/Plugin/Parsers/IcalResponseParser.php
+++ b/app/Services/Plugin/Parsers/IcalResponseParser.php
@@ -47,7 +47,7 @@ class IcalResponseParser implements ResponseParser
                     return false;
                 }
 
-                return $startDate->between($windowStart, $windowEnd, true) || $endDate->between($windowStart, $windowEnd, true) || $windowStart->between($startDate, $endDate, true) && $windowEnd->between($startDate, $endDate, true);
+                return $startDate->gte($windowStart) && $startDate->lt($windowEnd) || $endDate->gt($windowStart) && $endDate->lte($windowEnd) || $windowStart->gte($startDate) && $windowEnd->lte($endDate);
             }));
 
             $normalizedEvents = array_map($this->normalizeIcalEvent(...), $filteredEvents);

--- a/app/Services/Plugin/Parsers/IcalResponseParser.php
+++ b/app/Services/Plugin/Parsers/IcalResponseParser.php
@@ -36,9 +36,10 @@ class IcalResponseParser implements ResponseParser
             $this->parser->parseString($normalizedBody);
 
             $events = $this->parser->getEvents()->sorted()->getArrayCopy();
-            $now = now()->startOfDay();
+            $windowStart = now()->subDays(7);
+            $windowEnd = now()->addDays(30);
 
-            $filteredEvents = array_values(array_filter($events, function (array $event) use ($now): bool {
+            $filteredEvents = array_values(array_filter($events, function (array $event) use ($windowStart, $windowEnd): bool {
                 $startDate = $this->asCarbon($event['DTSTART'] ?? null);
                 $endDate = $this->asCarbon($event['DTEND'] ?? null);
 
@@ -46,11 +47,7 @@ class IcalResponseParser implements ResponseParser
                     return false;
                 }
 
-                if ($startDate->gte($now) || $endDate->gte($now)) {
-                    return true;
-                }
-
-                return false;
+                return $startDate->between($windowStart, $windowEnd, true) || $endDate->between($windowStart, $windowEnd, true) || $windowStart->between($startDate, $endDate, true) && $windowEnd->between($startDate, $endDate, true);
             }));
 
             $normalizedEvents = array_map($this->normalizeIcalEvent(...), $filteredEvents);

--- a/app/Services/Plugin/Parsers/IcalResponseParser.php
+++ b/app/Services/Plugin/Parsers/IcalResponseParser.php
@@ -36,17 +36,21 @@ class IcalResponseParser implements ResponseParser
             $this->parser->parseString($normalizedBody);
 
             $events = $this->parser->getEvents()->sorted()->getArrayCopy();
-            $windowStart = now()->subDays(7);
-            $windowEnd = now()->addDays(30);
+            $now = now()->startOfDay();
 
-            $filteredEvents = array_values(array_filter($events, function (array $event) use ($windowStart, $windowEnd): bool {
+            $filteredEvents = array_values(array_filter($events, function (array $event) use ($now): bool {
                 $startDate = $this->asCarbon($event['DTSTART'] ?? null);
+                $endDate = $this->asCarbon($event['DTEND'] ?? null);
 
-                if (! $startDate instanceof Carbon) {
+                if (! $startDate instanceof Carbon || ! $endDate instanceof Carbon) {
                     return false;
                 }
 
-                return $startDate->between($windowStart, $windowEnd, true);
+                if ($startDate->gte($now) || $endDate->gte($now)) {
+                    return true;
+                }
+
+                return false;
             }));
 
             $normalizedEvents = array_map($this->normalizeIcalEvent(...), $filteredEvents);

--- a/tests/Feature/Plugins/Ical/IcalParserMultidayWindowTest.php
+++ b/tests/Feature/Plugins/Ical/IcalParserMultidayWindowTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Plugin;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Dataset describing all multiday window test cases.
+ * Each item: [DTSTART, DTEND, shouldBeIncluded]
+ */
+dataset('multiday-window-cases', [
+    // 1. Ends before window -> exclude
+    ['20260220', '20260303', false],
+
+    // 2. Starts after window -> exclude
+    ['20260410', '20260425', false],
+
+    // 3. Ends exactly on window start day -> include
+    // ICS spec: all-day and multi-day events use an exclusive DTEND.
+    // If an event is said to end on March 3, the ICS will contain DTEND on March 4 at 00:00.
+    // Therefore the correct end date here is 20260304.
+    ['20260220', '20260304', true],
+
+    // 4. Ends inside window -> include
+    ['20260220', '20260315', true],
+
+    // 5. Ends exactly on window end day -> include
+    ['20260220', '20260410', true],
+
+    // 6. Ends after window -> include
+    ['20260220', '20260420', true],
+
+    // 7. Starts exactly on window start day, ends inside -> include
+    ['20260303', '20260315', true],
+
+    // 8. Starts exactly on window start day, ends on window end day -> include
+    ['20260303', '20260410', true],
+
+    // 9. Starts exactly on window start day, ends after window -> include
+    ['20260303', '20260420', true],
+
+    // 10. Starts inside window, ends inside -> include
+    ['20260320', '20260325', true],
+
+    // 11. Starts inside window, ends on window end day -> include
+    ['20260320', '20260410', true],
+
+    // 12. Starts inside window, ends after window -> include
+    ['20260320', '20260420', true],
+]);
+
+dataset('test-nows', [
+    'midnight' => '2026-03-10 00:00:00',
+    'noon'     => '2026-03-10 12:00:00',
+]);
+
+dataset('special-cases', [
+    // 13. Starts on window end day, ends after window
+    ['20260409', '20260420', false, '2026-03-10 00:00:00'],
+    ['20260409', '20260420', true, '2026-03-10 12:00:00'],
+]);
+
+test('IcalResponseParser filters multiday events correctly within the time window', function (
+    string $dtStart,
+    string $dtEnd,
+    bool $shouldBeIncluded,
+    string $now
+) {
+    Carbon::setTestNow(Carbon::parse($now, 'UTC'));
+
+    // Build ICS content for the given multiday event
+    $ics = <<<ICS
+BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Test//Multiday//EN
+BEGIN:VEVENT
+UID:multiday@example.com
+SUMMARY:Multiday
+DTSTART:{$dtStart}T000000Z
+DTEND:{$dtEnd}T000000Z
+END:VEVENT
+END:VCALENDAR
+ICS;
+
+    Http::fake([
+        'example.com/multiday.ics' => Http::response($ics, 200, ['Content-Type' => 'text/calendar']),
+    ]);
+
+    $plugin = Plugin::factory()->create([
+        'data_strategy' => 'polling',
+        'polling_url' => 'https://example.com/multiday.ics',
+        'polling_verb' => 'get',
+    ]);
+
+    $plugin->updateDataPayload();
+    $plugin->refresh();
+
+    $events = $plugin->data_payload['ical'] ?? [];
+
+    if ($shouldBeIncluded) {
+        expect($events)->toHaveCount(1);
+        expect($events[0]['SUMMARY'])->toBe('Multiday');
+    } else {
+        expect($events)->toBeEmpty();
+    }
+
+    Carbon::setTestNow();
+})
+    ->with('multiday-window-cases')
+    ->with('test-nows')
+    ->with('special-cases');


### PR DESCRIPTION
### Summary

This change fixes an issue where long multi‑day events were not shown in the calendar when their start date fell outside the configured time window. For example, a summer holiday spanning several weeks would disappear once its `DTSTART` moved out of range, even though the event was still ongoing.

### What was wrong

The previous filtering logic only checked whether the event’s start date was inside the window. As a result, multi‑day events that began before the window but still overlapped with it were incorrectly excluded.

### What this patch does

- Preserves the original time‑window behaviour (`windowStart = now − 7 days`, `windowEnd = now + 30 days`).
- Fixes multi‑day event handling by keeping any event that overlaps with the window in **any** meaningful way:
  - the event starts inside the window,
  - the event ends inside the window,
  - or the entire window falls within the event’s date range.

This ensures that ongoing multi‑day events remain visible throughout their duration, without altering the intended window‑based filtering.