### PR TITLE
feat: only render new image if content has changed

### DIFF
--- a/app/Services/ImageGenerationService.php
+++ b/app/Services/ImageGenerationService.php
@@ -74,6 +74,8 @@ class ImageGenerationService
         ?Device $device = null,
         ?Plugin $plugin = null,
     ): string {
+        // Random name only for the throwaway temp file; the stored filename is the
+        // content hash returned by storeByContentHash() below.
         $uuid = Uuid::uuid4()->toString();
 
         try {
@@ -146,14 +148,14 @@ class ImageGenerationService
                     ->pipe($imageStage)
                     ->process();
 
-                self::storeGeneratedImageOnPublicDisk($localOutputPath, $uuid, $fileExtension);
+                $hash = self::storeByContentHash($localOutputPath, $fileExtension);
             } finally {
                 $temporaryDirectory->delete();
             }
 
-            Log::info("Generated image: $uuid");
+            Log::info("Generated image: $hash");
 
-            return $uuid;
+            return $hash;
 
         } catch (Exception $e) {
             Log::error('Failed to generate image: '.$e->getMessage());
@@ -298,24 +300,37 @@ class ImageGenerationService
     }
 
     /**
-     * Copy a pipeline output file from local disk into the public storage disk.
+     * Store the generated image using a content-addressed filename (a hash of
+     * the image bytes). This prevents the TRMNL from downloading or redrawing
+     * when the image hasn't changed.
+     *
+     * @return string The content hash used as the stored filename stem.
      *
      * @throws RuntimeException
      */
-    private static function storeGeneratedImageOnPublicDisk(string $localOutputPath, string $uuid, string $fileExtension): void
+    private static function storeByContentHash(string $localOutputPath, string $fileExtension): string
     {
         if (! file_exists($localOutputPath)) {
             throw new RuntimeException('Image file was not created: '.$localOutputPath);
         }
 
-        $storedPath = 'images/generated/'.$uuid.'.'.$fileExtension;
         $bytes = file_get_contents($localOutputPath);
         if ($bytes === false || $bytes === '') {
             throw new RuntimeException('Image file was empty or could not be read: '.$localOutputPath);
         }
+
+        $hash = hash('sha256', $bytes);
+        $storedPath = 'images/generated/'.$hash.'.'.$fileExtension;
+
+        if (Storage::disk('public')->exists($storedPath)) {
+            return $hash;
+        }
+
         if (! Storage::disk('public')->put($storedPath, $bytes)) {
             throw new RuntimeException('Failed to store generated image at: '.$storedPath);
         }
+
+        return $hash;
     }
 
     /**
@@ -506,6 +521,8 @@ class ImageGenerationService
             throw new InvalidArgumentException("Invalid image type: {$imageType}");
         }
 
+        // Random name only for the throwaway temp file; the stored filename is the
+        // content hash returned by storeByContentHash() below.
         $uuid = Uuid::uuid4()->toString();
 
         try {
@@ -568,14 +585,14 @@ class ImageGenerationService
                     ->pipe($imageStage)
                     ->process();
 
-                self::storeGeneratedImageOnPublicDisk($localOutputPath, $uuid, $fileExtension);
+                $hash = self::storeByContentHash($localOutputPath, $fileExtension);
             } finally {
                 $temporaryDirectory->delete();
             }
 
-            Log::info("Device $device->id: generated default screen image: $uuid for type: $imageType");
+            Log::info("Device $device->id: generated default screen image: $hash for type: $imageType");
 
-            return $uuid;
+            return $hash;
 
         } catch (Exception $e) {
             Log::error('Failed to generate default screen image: '.$e->getMessage());

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -627,7 +627,12 @@ test('plugin caches image until data is stale', function (): void {
     expect($secondResponse['filename'])
         ->toBe($firstResponse['filename']);
 
-    // third request after 75 seconds, should generate a new image
+    // third request after 75 seconds, should re-render (data is now stale).
+    // The generated image may be identical to before, and have the same
+    // filename (due to content-addressed filenames), so instead of checking for
+    // a different filename we need to check the updated timestamp.
+    $previousPayloadUpdatedAt = $plugin->fresh()->data_payload_updated_at;
+
     $plugin->update(['data_payload_updated_at' => now()->addSeconds(-75)]);
     $thirdResponse = $this->withHeaders([
         'id' => $device->mac_address,
@@ -637,8 +642,10 @@ test('plugin caches image until data is stale', function (): void {
         'fw-version' => '1.0.0',
     ])->get('/api/display');
 
-    expect($thirdResponse['filename'])
-        ->not->toBe($firstResponse['filename']);
+    $thirdResponse->assertOk();
+    expect($plugin->fresh()->data_payload_updated_at)
+        ->not->toBe($previousPayloadUpdatedAt);
+    expect($thirdResponse['filename'])->not->toBe('setup-logo.bmp');
 });
 
 test('plugins in playlist are rendered in order', function (): void {
@@ -726,9 +733,7 @@ test('plugins in playlist are rendered in order', function (): void {
     ])->get('/api/display');
 
     $secondResponse->assertOk();
-    expect($secondResponse['filename'])
-        ->not->toBe($firstImageFilename)
-        ->not->toBe('setup-logo.bmp');
+    expect($secondResponse['filename'])->not->toBe('setup-logo.bmp');
 
     // Get the second plugin's playlist item and verify it was marked as displayed
     $secondPluginItem = PlaylistItem::where('plugin_id', $secondPlugin->id)->first();
@@ -744,8 +749,6 @@ test('plugins in playlist are rendered in order', function (): void {
     ])->get('/api/display');
 
     $thirdResponse->assertOk();
-    expect($thirdResponse['filename'])
-        ->not->toBe($secondResponse['filename']);
 });
 
 test('display endpoint keeps current screen when all active playlist items are skipped', function (): void {

--- a/tests/Feature/GenerateDefaultImagesTest.php
+++ b/tests/Feature/GenerateDefaultImagesTest.php
@@ -85,7 +85,9 @@ test('generateDefaultScreenImage creates images from Blade templates', function 
 
     expect($setupUuid)->not->toBeEmpty();
     expect($sleepUuid)->not->toBeEmpty();
-    expect($setupUuid)->not->toBe($sleepUuid);
+    // If the tests render the same content for both images, they may hash down
+    // to the same filename and receive the same identifier. Assert both produce
+    // a valid identifier and file rather than asserting they are different images.
 
     $setupPath = "images/generated/{$setupUuid}.png";
     $sleepPath = "images/generated/{$sleepUuid}.png";

--- a/tests/Feature/ImageGenerationServiceTest.php
+++ b/tests/Feature/ImageGenerationServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\ImageFormat;
 use App\Models\Device;
 use App\Models\DeviceModel;
+use App\Services\DeviceImageResolver;
 use App\Services\ImageGenerationService;
 use Bnussbau\EpaperPipeline\EpaperPipeline;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -499,4 +500,132 @@ it('generates BMP for legacy device with bmp3_1bit_srgb format', function (): vo
     expect($imageInfo[0])->toBe(800); // Width
     expect($imageInfo[1])->toBe(480); // Height
     expect($imageInfo[2])->toBe(IMAGETYPE_BMP); // BMP type
+});
+
+it('returns the same identifier when the same markup is rendered twice', function (): void {
+    $device = Device::factory()->create([
+        'width' => 800,
+        'height' => 480,
+        'rotate' => 0,
+        'image_format' => ImageFormat::PNG_8BIT_GRAYSCALE->value,
+    ]);
+
+    $markup = '<div style="background: white; color: black;">Stable content</div>';
+
+    $firstHash = ImageGenerationService::generateImage($markup, $device->id);
+    $secondHash = ImageGenerationService::generateImage($markup, $device->id);
+
+    expect($secondHash)->toBe($firstHash);
+    Storage::disk('public')->assertExists("/images/generated/{$firstHash}.png");
+});
+
+it('returns different identifiers for different rendered content', function (): void {
+    // Render at different dimensions so the produced bytes differ, otherwise
+    // the fake pipeline yields identical pixels for any markup.
+    $smallDevice = Device::factory()->create([
+        'width' => 800,
+        'height' => 480,
+        'rotate' => 0,
+        'image_format' => ImageFormat::AUTO->value,
+    ]);
+    $largeDevice = Device::factory()->create([
+        'width' => 1024,
+        'height' => 768,
+        'rotate' => 0,
+        'image_format' => ImageFormat::AUTO->value,
+    ]);
+
+    $markup = '<div>Test</div>';
+    $smallHash = ImageGenerationService::generateImage($markup, $smallDevice->id);
+    $largeHash = ImageGenerationService::generateImage($markup, $largeDevice->id);
+
+    expect($largeHash)->not->toBe($smallHash);
+    Storage::disk('public')->assertExists("/images/generated/{$smallHash}.png");
+    Storage::disk('public')->assertExists("/images/generated/{$largeHash}.png");
+});
+
+it('does not write a duplicate file when content already exists on disk', function (): void {
+    $device = Device::factory()->create([
+        'width' => 800,
+        'height' => 480,
+        'rotate' => 0,
+        'image_format' => ImageFormat::PNG_8BIT_GRAYSCALE->value,
+    ]);
+
+    $markup = '<div>Stable</div>';
+    $hash = ImageGenerationService::generateImage($markup, $device->id);
+    $path = "/images/generated/{$hash}.png";
+    Storage::disk('public')->assertExists($path);
+
+    // Mutate the stored file's mtime so a re-write would be observable, then
+    // re-render: content-addressing should hit the existence short-circuit and
+    // leave the original file untouched.
+    $originalMtime = filemtime(Storage::disk('public')->path($path));
+    sleep(1);
+
+    $secondHash = ImageGenerationService::generateImage($markup, $device->id);
+
+    expect($secondHash)->toBe($hash);
+    $files = Storage::disk('public')->files('/images/generated');
+    $matching = array_filter($files, fn (string $f): bool => str_starts_with(basename($f), $hash));
+    expect($matching)->toHaveCount(1);
+    clearstatcache();
+    expect(filemtime(Storage::disk('public')->path($path)))->toBe($originalMtime);
+});
+
+it('produces a hex content hash identifier, not a uuid', function (): void {
+    $device = Device::factory()->create([
+        'width' => 800,
+        'height' => 480,
+        'rotate' => 0,
+        'image_format' => ImageFormat::PNG_8BIT_GRAYSCALE->value,
+    ]);
+
+    $hash = ImageGenerationService::generateImage('<div>Test</div>', $device->id);
+
+    // sha256 hex: 64 lowercase hex chars, not a dashed uuid.
+    expect($hash)->toMatch('/^[0-9a-f]{64}$/');
+    expect($hash)->not->toContain('-');
+});
+
+it('returns a stable identifier for repeated default-screen renders of the same type', function (): void {
+    $device = Device::factory()->create();
+
+    $first = ImageGenerationService::generateDefaultScreenImage($device, 'sleep');
+    $second = ImageGenerationService::generateDefaultScreenImage($device, 'sleep');
+
+    expect($second)->toBe($first);
+    Storage::disk('public')->assertExists("/images/generated/{$first}.png");
+});
+
+it('cleanupFolder preserves a hash filename referenced by a device and removes unreferenced ones', function (): void {
+    $activeHash = hash('sha256', 'active-image-bytes');
+    $inactiveHash = hash('sha256', 'inactive-image-bytes');
+
+    Device::factory()->create(['current_screen_image' => $activeHash]);
+
+    Storage::disk('public')->put("/images/generated/{$activeHash}.png", 'active-image-bytes');
+    Storage::disk('public')->put("/images/generated/{$inactiveHash}.png", 'inactive-image-bytes');
+
+    ImageGenerationService::cleanupFolder();
+
+    Storage::disk('public')->assertExists("/images/generated/{$activeHash}.png");
+    Storage::disk('public')->assertMissing("/images/generated/{$inactiveHash}.png");
+});
+
+it('DeviceImageResolver resolves a hex-hash identifier to its stored file', function (): void {
+    $device = Device::factory()->create([
+        'width' => 800,
+        'height' => 480,
+        'rotate' => 0,
+        'image_format' => ImageFormat::PNG_8BIT_GRAYSCALE->value,
+    ]);
+
+    $hash = ImageGenerationService::generateImage('<div>Test</div>', $device->id);
+
+    $resolver = new DeviceImageResolver;
+    $resolved = $resolver->resolve($device, $hash);
+
+    expect($resolved)->toBe("images/generated/{$hash}.png");
+    Storage::disk('public')->assertExists($resolved);
 });

--- a/tests/Feature/TransformDefaultImagesTest.php
+++ b/tests/Feature/TransformDefaultImagesTest.php
@@ -61,7 +61,10 @@ test('generateDefaultScreenImage creates images from Blade templates', function 
 
     expect($setupUuid)->not->toBeEmpty();
     expect($sleepUuid)->not->toBeEmpty();
-    expect($setupUuid)->not->toBe($sleepUuid);
+    // Under content-addressed caching the filename is derived from image bytes;
+    // the fake pipeline renders identical pixels for both templates, so setup and
+    // sleep screens may share a hash. Assert both produce a valid identifier and
+    // file rather than asserting they differ.
 
     // Check that the generated images exist
     $setupPath = "images/generated/{$setupUuid}.png";


### PR DESCRIPTION
My trmnl sits on one screen all day (my task list). I noticed that it was constantly redrawing even though the content hadn't changed. This was because on every refresh larapaper generated a new file and named it with a UUID, so the trmnl always  thought the image is stale.

This PR hashes the generated image and uses the hash as the filename. Now my trmnl doesn't download + redraw until the displayed image is actually different.