### PR TITLE
Add specific-date device pauses

### DIFF
--- a/app/Actions/Api/RunDeviceDisplayCycle.php
+++ b/app/Actions/Api/RunDeviceDisplayCycle.php
@@ -28,7 +28,7 @@ class RunDeviceDisplayCycle
         if ($device->isPauseActive()) {
             return [
                 'image_path' => $this->defaultImagePath($device, 'sleep'),
-                'refresh_time_override' => (int) now()->diffInSeconds($device->pause_until),
+                'refresh_time_override' => min((int) now()->diffInSeconds($device->pause_until), 86400),
             ];
         }
 

--- a/resources/views/livewire/devices/configure.blade.php
+++ b/resources/views/livewire/devices/configure.blade.php
@@ -75,6 +75,15 @@ new class extends Component
 
     public $download_firmware;
 
+    public function effectiveTimezone(): string
+    {
+        $timezone = auth()->user()->timezone;
+
+        return is_string($timezone) && in_array($timezone, timezone_identifiers_list(), true)
+            ? $timezone
+            : config('app.timezone');
+    }
+
     public function mount(App\Models\Device $device)
     {
         abort_unless(auth()->user()->devices->contains($device), 403);
@@ -442,7 +451,7 @@ new class extends Component
                         @endif
                         @if($device->isPauseActive())
                             <flux:separator vertical/>
-                            <flux:tooltip content="Pause active until {{$device->pause_until?->format('H:i')}}"
+                            <flux:tooltip content="Pause active until {{$device->pause_until?->copy()->timezone($this->effectiveTimezone())->format('Y-m-d H:i')}}"
                                           position="bottom">
                                 <flux:icon name="pause-circle" variant="solid"/>
                             </flux:tooltip>

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -146,7 +146,7 @@ new class extends Component
                             return;
                         }
 
-                        if ($pauseUntil->format('Y-m-d\\TH:i') !== $value) {
+                        if ($pauseUntil?->format('Y-m-d\\TH:i') !== $value) {
                             $fail('The pause until value must be a valid local date and time.');
 
                             return;

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -113,6 +113,15 @@ new class extends Component
         $this->resetErrorBag(['pause_duration', 'pause_until']);
     }
 
+    public function effectiveTimezone(): string
+    {
+        $timezone = auth()->user()->timezone;
+
+        return is_string($timezone) && in_array($timezone, timezone_identifiers_list(), true)
+            ? $timezone
+            : config('app.timezone');
+    }
+
     public function pauseDevice($deviceId): void
     {
         $this->validate([
@@ -120,7 +129,7 @@ new class extends Component
         ]);
 
         $device = auth()->user()->devices()->findOrFail($deviceId);
-        $timezone = auth()->user()->timezone ?: config('app.timezone');
+        $timezone = $this->effectiveTimezone();
 
         if ($this->pause_duration === 'specific_date') {
             $this->validate([
@@ -311,7 +320,7 @@ new class extends Component
                                 <flux:button href="{{ route('devices.configure', $device) }}" wire:navigate icon="eye" iconVariant="outline">
                                 </flux:button>
                                 @if($device->isPauseActive())
-                                    <flux:tooltip content="Device paused until: {{ $device->pause_until?->copy()->timezone(auth()->user()->timezone ?: config('app.timezone'))->format('Y-m-d H:i') }}">
+                                    <flux:tooltip content="Device paused until: {{ $device->pause_until?->copy()->timezone($this->effectiveTimezone())->format('Y-m-d H:i') }}">
                                         <flux:button icon="pause-circle"/>
                                     </flux:tooltip>
                                 @else
@@ -365,7 +374,7 @@ new class extends Component
                         <div class="mb-4">
                             <flux:input wire:model="pause_until" label="Pause until" type="datetime-local"/>
                             <p class="mt-2 text-sm text-zinc-500">
-                                Times are interpreted in {{ auth()->user()->timezone ?: config('app.timezone') }}.
+                                Times are interpreted in {{ $this->effectiveTimezone() }}.
                             </p>
                         </div>
                     @endif

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -107,6 +107,12 @@ new class extends Component
         // }
     }
 
+    public function resetPauseForm(): void
+    {
+        $this->reset('pause_duration', 'pause_until');
+        $this->resetErrorBag(['pause_duration', 'pause_until']);
+    }
+
     public function pauseDevice($deviceId): void
     {
         $this->validate([
@@ -154,7 +160,7 @@ new class extends Component
         $this->reset('pause_duration', 'pause_until');
         Flux::modal('pause-device-'.$deviceId)->close();
         $this->devices = auth()->user()->devices;
-        Flux::toast(variant: 'success', text: 'Device paused until '.$pauseUntil->copy()->timezone($timezone)->format('H:i'));
+        Flux::toast(variant: 'success', text: 'Device paused until '.$pauseUntil->copy()->timezone($timezone)->format('Y-m-d H:i'));
     }
 }
 
@@ -305,11 +311,11 @@ new class extends Component
                                 <flux:button href="{{ route('devices.configure', $device) }}" wire:navigate icon="eye" iconVariant="outline">
                                 </flux:button>
                                 @if($device->isPauseActive())
-                                    <flux:tooltip content="Device paused until: {{ $device->pause_until?->format('H:i') }}">
+                                    <flux:tooltip content="Device paused until: {{ $device->pause_until?->copy()->timezone(auth()->user()->timezone ?: config('app.timezone'))->format('Y-m-d H:i') }}">
                                         <flux:button icon="pause-circle"/>
                                     </flux:tooltip>
                                 @else
-                                    <flux:modal.trigger name="pause-device-{{ $device->id }}">
+                                    <flux:modal.trigger name="pause-device-{{ $device->id }}" wire:click="resetPauseForm">
                                         <flux:button icon="pause-circle" iconVariant="outline">
                                         </flux:button>
                                     </flux:modal.trigger>
@@ -366,7 +372,7 @@ new class extends Component
                     <div class="flex">
                         <flux:spacer/>
                         <flux:modal.close>
-                            <flux:button variant="ghost">Cancel</flux:button>
+                            <flux:button wire:click="resetPauseForm" variant="ghost">Cancel</flux:button>
                         </flux:modal.close>
                         <flux:button type="submit" variant="primary">Save</flux:button>
                     </div>

--- a/resources/views/livewire/devices/manage.blade.php
+++ b/resources/views/livewire/devices/manage.blade.php
@@ -2,6 +2,8 @@
 
 use App\Models\Device;
 use App\Models\DeviceModel;
+use Carbon\Carbon;
+use Illuminate\Validation\Rule;
 use Livewire\Component;
 
 new class extends Component
@@ -28,7 +30,9 @@ new class extends Component
 
     public $deviceModels;
 
-    public ?int $pause_duration;
+    public ?string $pause_duration = null;
+
+    public ?string $pause_until = null;
 
     protected $rules = [
         'mac_address' => 'required',
@@ -106,15 +110,51 @@ new class extends Component
     public function pauseDevice($deviceId): void
     {
         $this->validate([
-            'pause_duration' => 'required|integer',
+            'pause_duration' => ['required', Rule::in(['30', '60', '120', '240', '480', 'specific_date'])],
         ]);
+
         $device = auth()->user()->devices()->findOrFail($deviceId);
-        $pauseUntil = now()->addMinutes($this->pause_duration);
+        $timezone = auth()->user()->timezone ?: config('app.timezone');
+
+        if ($this->pause_duration === 'specific_date') {
+            $this->validate([
+                'pause_until' => [
+                    'required',
+                    'string',
+                    'regex:/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/',
+                    function (string $attribute, mixed $value, Closure $fail) use ($timezone): void {
+                        try {
+                            $pauseUntil = Carbon::createFromFormat('!Y-m-d\\TH:i', $value, $timezone);
+                        } catch (Throwable) {
+                            $fail('The pause until value must be a valid local date and time.');
+
+                            return;
+                        }
+
+                        if ($pauseUntil->format('Y-m-d\\TH:i') !== $value) {
+                            $fail('The pause until value must be a valid local date and time.');
+
+                            return;
+                        }
+
+                        if (! $pauseUntil->isAfter(now())) {
+                            $fail('The pause until value must be in the future.');
+                        }
+                    },
+                ],
+            ]);
+
+            $pauseUntil = Carbon::createFromFormat('!Y-m-d\\TH:i', $this->pause_until, $timezone)
+                ->timezone(config('app.timezone'));
+        } else {
+            $pauseUntil = now()->addMinutes((int) $this->pause_duration);
+        }
+
         $device->update(['pause_until' => $pauseUntil]);
-        $this->reset('pause_duration');
+        $this->reset('pause_duration', 'pause_until');
         Flux::modal('pause-device-'.$deviceId)->close();
         $this->devices = auth()->user()->devices;
-        Flux::toast(variant: 'success', text: 'Device paused until '.$pauseUntil->format('H:i'));
+        Flux::toast(variant: 'success', text: 'Device paused until '.$pauseUntil->copy()->timezone($timezone)->format('H:i'));
     }
 }
 
@@ -312,8 +352,17 @@ new class extends Component
                             <flux:radio value="120" label="120 min"/>
                             <flux:radio value="240" label="240 min"/>
                             <flux:radio value="480" label="480 min"/>
+                            <flux:radio value="specific_date" label="Specific date and time"/>
                         </flux:radio.group>
                     </div>
+                    @if ($pause_duration === 'specific_date')
+                        <div class="mb-4">
+                            <flux:input wire:model="pause_until" label="Pause until" type="datetime-local"/>
+                            <p class="mt-2 text-sm text-zinc-500">
+                                Times are interpreted in {{ auth()->user()->timezone ?: config('app.timezone') }}.
+                            </p>
+                        </div>
+                    @endif
                     <div class="flex">
                         <flux:spacer/>
                         <flux:modal.close>

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -1556,12 +1556,14 @@ test('display status update requires sleep mode times when sleep mode is enabled
         ->assertJsonValidationErrors(['sleep_mode_from']);
 });
 
-test('device returns sleep.png and correct refresh time when paused', function (): void {
+test('paused device returns the sleep image with the expected capped refresh interval', function (int $remainingSeconds, int $expectedRefresh): void {
+    Carbon\Carbon::setTestNow('2026-01-15 12:00:00 UTC');
     $device = Device::factory()->create([
         'mac_address' => '00:11:22:33:44:55',
         'api_key' => 'test-api-key',
-        'pause_until' => now()->addMinutes(60),
+        'pause_until' => now()->addSeconds($remainingSeconds),
     ]);
+    Storage::disk('public')->put('images/sleep.png', 'sleep');
 
     $response = $this->withHeaders([
         'id' => $device->mac_address,
@@ -1574,11 +1576,46 @@ test('device returns sleep.png and correct refresh time when paused', function (
     $response->assertOk();
     $json = $response->json();
 
-    // The filename should be a UUID-based PNG file since we're generating from template
-    expect($json['filename'])->toMatch('/^[a-f0-9-]+\.png$/');
-    expect($json['image_url'])->toContain('images/generated/');
-    expect($json['refresh_rate'])->toBeLessThanOrEqual(3600); // ~60 min
-});
+    expect($json['filename'])->toBe('sleep.png');
+    expect($json['image_url'])->toContain('images/sleep.png');
+    expect($json['refresh_rate'])->toBe($expectedRefresh);
+
+    Carbon\Carbon::setTestNow();
+})->with([
+    'more than 24 hours remaining' => [172800, 86400],
+    'exactly 24 hours remaining' => [86400, 86400],
+    'less than 24 hours remaining' => [3600, 3600],
+]);
+
+test('equal and expired pauses use the normal display refresh interval', function (int $remainingSeconds): void {
+    Carbon\Carbon::setTestNow('2026-01-15 12:00:00 UTC');
+    $device = Device::factory()->create([
+        'mac_address' => '00:11:22:33:44:55',
+        'api_key' => 'test-api-key',
+        'current_screen_image' => 'current-image',
+        'default_refresh_interval' => 1234,
+        'pause_until' => now()->addSeconds($remainingSeconds),
+    ]);
+
+    $response = $this->withHeaders([
+        'id' => $device->mac_address,
+        'access-token' => $device->api_key,
+        'rssi' => -70,
+        'battery_voltage' => 3.8,
+        'fw-version' => '1.0.0',
+    ])->get('/api/display');
+
+    $response->assertOk()
+        ->assertJson([
+            'filename' => 'current-image.bmp',
+            'refresh_rate' => 1234,
+        ]);
+
+    Carbon\Carbon::setTestNow();
+})->with([
+    'equal to now' => 0,
+    'expired' => -60,
+]);
 
 test('screens endpoint accepts nullable file_name', function (): void {
     Queue::fake();

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -17,6 +17,13 @@ use Laravel\Sanctum\Sanctum;
 
 uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+$originalPhpTimezone = date_default_timezone_get();
+
+afterEach(function () use ($originalPhpTimezone): void {
+    Carbon\Carbon::setTestNow();
+    date_default_timezone_set($originalPhpTimezone);
+});
+
 beforeEach(function (): void {
     EpaperPipeline::fake();
     Storage::fake('public');
@@ -1558,12 +1565,13 @@ test('display status update requires sleep mode times when sleep mode is enabled
 
 test('paused device returns the sleep image with the expected capped refresh interval', function (int $remainingSeconds, int $expectedRefresh): void {
     Carbon\Carbon::setTestNow('2026-01-15 12:00:00 UTC');
+    expect(file_exists(storage_path('app/public/images/sleep.bmp')))->toBeTrue();
     $device = Device::factory()->create([
         'mac_address' => '00:11:22:33:44:55',
         'api_key' => 'test-api-key',
         'pause_until' => now()->addSeconds($remainingSeconds),
     ]);
-    Storage::disk('public')->put('images/sleep.png', 'sleep');
+    Storage::disk('public')->put('images/sleep.bmp', 'sleep');
 
     $response = $this->withHeaders([
         'id' => $device->mac_address,
@@ -1576,8 +1584,8 @@ test('paused device returns the sleep image with the expected capped refresh int
     $response->assertOk();
     $json = $response->json();
 
-    expect($json['filename'])->toBe('sleep.png');
-    expect($json['image_url'])->toContain('images/sleep.png');
+    expect($json['filename'])->toBe('sleep.bmp');
+    expect($json['image_url'])->toContain('images/sleep.bmp');
     expect($json['refresh_rate'])->toBe($expectedRefresh);
 
     Carbon\Carbon::setTestNow();

--- a/tests/Feature/Api/DeviceEndpointsTest.php
+++ b/tests/Feature/Api/DeviceEndpointsTest.php
@@ -1565,13 +1565,15 @@ test('display status update requires sleep mode times when sleep mode is enabled
 
 test('paused device returns the sleep image with the expected capped refresh interval', function (int $remainingSeconds, int $expectedRefresh): void {
     Carbon\Carbon::setTestNow('2026-01-15 12:00:00 UTC');
-    expect(file_exists(storage_path('app/public/images/sleep.bmp')))->toBeTrue();
+    $sleepImagePath = storage_path('app/public/images/sleep.bmp');
+    expect(is_file($sleepImagePath))->toBeTrue();
     $device = Device::factory()->create([
         'mac_address' => '00:11:22:33:44:55',
         'api_key' => 'test-api-key',
         'pause_until' => now()->addSeconds($remainingSeconds),
     ]);
-    Storage::disk('public')->put('images/sleep.bmp', 'sleep');
+    Storage::disk('public')->put('images/sleep.bmp', file_get_contents($sleepImagePath));
+    Storage::disk('public')->assertExists('images/sleep.bmp');
 
     $response = $this->withHeaders([
         'id' => $device->mac_address,

--- a/tests/Feature/Devices/DeviceConfigureTest.php
+++ b/tests/Feature/Devices/DeviceConfigureTest.php
@@ -7,12 +7,20 @@ use App\Models\Playlist;
 use App\Models\PlaylistItem;
 use App\Models\Plugin;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 
 uses(RefreshDatabase::class);
+
+$originalPhpTimezone = date_default_timezone_get();
+
+afterEach(function () use ($originalPhpTimezone): void {
+    Carbon::setTestNow();
+    date_default_timezone_set($originalPhpTimezone);
+});
 
 test('configure view displays last_refreshed_at timestamp', function (): void {
     $user = User::factory()->create();
@@ -27,6 +35,26 @@ test('configure view displays last_refreshed_at timestamp', function (): void {
     $response->assertOk()
         ->assertSee('5 minutes ago');
 });
+
+test('configure view displays an active pause deadline with a complete date in the effective timezone', function (?string $timezone, string $expectedDeadline): void {
+    config(['app.timezone' => 'UTC']);
+    date_default_timezone_set('UTC');
+    Carbon::setTestNow('2026-01-01 00:00:00 UTC');
+    $user = User::factory()->create(['timezone' => $timezone]);
+    $device = Device::factory()->create([
+        'user_id' => $user->id,
+        'pause_until' => Carbon::parse('2026-09-01 12:00:00 UTC'),
+    ]);
+
+    actingAs($user)
+        ->get(route('devices.configure', $device))
+        ->assertOk()
+        ->assertSee('Pause active until '.$expectedDeadline)
+        ->assertDontSee('Pause active until 12:00');
+})->with([
+    'owner timezone' => ['Europe/Amsterdam', '2026-09-01 14:00'],
+    'invalid legacy timezone falls back to app timezone' => ['Not/AZone', '2026-09-01 12:00'],
+]);
 
 test('configure edit modal shows mirror checkbox and allows unchecking mirror', function (): void {
     $user = User::factory()->create();

--- a/tests/Feature/Devices/ManageTest.php
+++ b/tests/Feature/Devices/ManageTest.php
@@ -6,6 +6,13 @@ use Carbon\Carbon;
 
 uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
 
+$originalPhpTimezone = date_default_timezone_get();
+
+afterEach(function () use ($originalPhpTimezone): void {
+    Carbon::setTestNow();
+    date_default_timezone_set($originalPhpTimezone);
+});
+
 test('device management page can be rendered', function (): void {
     $user = User::factory()->create();
 
@@ -113,9 +120,49 @@ test('pause modal keeps the fixed presets and offers a specific date and time', 
     Livewire::test('devices.manage')
         ->assertSee(['30 min', '60 min', '120 min', '240 min', '480 min'])
         ->assertSee('Specific date and time')
+        ->assertSeeHtml('wire:model.live="pause_duration"')
+        ->assertSeeHtml('value="specific_date"')
         ->set('pause_duration', 'specific_date')
         ->assertSeeHtml('type="datetime-local"')
+        ->assertSeeHtml('wire:model="pause_until"')
         ->assertSee('Europe/Amsterdam');
+});
+
+test('active pause deadline is shown in the owners timezone with a complete local date', function (): void {
+    config(['app.timezone' => 'UTC']);
+    date_default_timezone_set('UTC');
+    Carbon::setTestNow('2026-01-01 00:00:00 UTC');
+    $user = User::factory()->create(['timezone' => 'Europe/Amsterdam']);
+    Device::factory()->create([
+        'user_id' => $user->id,
+        'pause_until' => Carbon::parse('2026-01-15 11:30:00 UTC'),
+    ]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->assertSee('Device paused until: 2026-01-15 12:30')
+        ->assertDontSee('Device paused until: 2026-01-15 11:30');
+});
+
+test('pause form state and errors are cleared when reopening or cancelling a pause modal', function (): void {
+    $user = User::factory()->create(['timezone' => 'UTC']);
+    $device = Device::factory()->create(['user_id' => $user->id]);
+    $this->actingAs($user);
+
+    $component = Livewire::test('devices.manage')
+        ->assertSeeHtml('wire:click="resetPauseForm"');
+
+    expect(mb_substr_count($component->html(), 'wire:click="resetPauseForm"'))->toBe(2);
+
+    $component
+        ->set('pause_duration', 'specific_date')
+        ->set('pause_until', null)
+        ->call('pauseDevice', $device->id)
+        ->assertHasErrors(['pause_until'])
+        ->call('resetPauseForm')
+        ->assertSet('pause_duration', null)
+        ->assertSet('pause_until', null)
+        ->assertHasNoErrors();
 });
 
 test('user can pause a device using each fixed preset', function (int $minutes): void {
@@ -206,6 +253,23 @@ test('invalid specific pause values leave the device unchanged', function (?stri
     'malformed date' => '2026-1-15T12:30',
     'nonexistent Amsterdam spring-forward time' => '2026-03-29T02:30',
 ]);
+
+test('an invalid stored user timezone rejects a custom pause without mutation', function (): void {
+    config(['app.timezone' => 'UTC']);
+    Carbon::setTestNow('2026-01-01 00:00:00 UTC');
+    $user = User::factory()->create(['timezone' => 'Not/AZone']);
+    $sentinel = Carbon::parse('2025-12-01 00:00:00 UTC');
+    $device = Device::factory()->create(['user_id' => $user->id, 'pause_until' => $sentinel]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->set('pause_duration', 'specific_date')
+        ->set('pause_until', '2026-01-15T12:30')
+        ->call('pauseDevice', $device->id)
+        ->assertHasErrors(['pause_until']);
+
+    expect($device->fresh()->pause_until->equalTo($sentinel))->toBeTrue();
+});
 
 test('past and equal specific pause instants leave the device unchanged', function (string $pauseUntil): void {
     config(['app.timezone' => 'UTC']);

--- a/tests/Feature/Devices/ManageTest.php
+++ b/tests/Feature/Devices/ManageTest.php
@@ -254,21 +254,26 @@ test('invalid specific pause values leave the device unchanged', function (?stri
     'nonexistent Amsterdam spring-forward time' => '2026-03-29T02:30',
 ]);
 
-test('an invalid stored user timezone rejects a custom pause without mutation', function (): void {
+test('an invalid stored user timezone falls back to the app timezone for active pauses and custom inputs', function (): void {
     config(['app.timezone' => 'UTC']);
+    date_default_timezone_set('UTC');
     Carbon::setTestNow('2026-01-01 00:00:00 UTC');
     $user = User::factory()->create(['timezone' => 'Not/AZone']);
-    $sentinel = Carbon::parse('2025-12-01 00:00:00 UTC');
-    $device = Device::factory()->create(['user_id' => $user->id, 'pause_until' => $sentinel]);
+    $device = Device::factory()->create([
+        'user_id' => $user->id,
+        'pause_until' => Carbon::parse('2026-01-15 12:30:00 UTC'),
+    ]);
     $this->actingAs($user);
 
     Livewire::test('devices.manage')
+        ->assertSee('Device paused until: 2026-01-15 12:30')
         ->set('pause_duration', 'specific_date')
-        ->set('pause_until', '2026-01-15T12:30')
+        ->assertSee('Times are interpreted in UTC.')
+        ->set('pause_until', '2026-01-16T14:30')
         ->call('pauseDevice', $device->id)
-        ->assertHasErrors(['pause_until']);
+        ->assertHasNoErrors();
 
-    expect($device->fresh()->pause_until->equalTo($sentinel))->toBeTrue();
+    expect($device->fresh()->pause_until->utc()->format('Y-m-d H:i:s'))->toBe('2026-01-16 14:30:00');
 });
 
 test('past and equal specific pause instants leave the device unchanged', function (string $pauseUntil): void {

--- a/tests/Feature/Devices/ManageTest.php
+++ b/tests/Feature/Devices/ManageTest.php
@@ -122,6 +122,7 @@ test('pause modal keeps the fixed presets and offers a specific date and time', 
         ->assertSee('Specific date and time')
         ->assertSeeHtml('wire:model.live="pause_duration"')
         ->assertSeeHtml('value="specific_date"')
+        ->assertDontSeeHtml('type="datetime-local"')
         ->set('pause_duration', 'specific_date')
         ->assertSeeHtml('type="datetime-local"')
         ->assertSeeHtml('wire:model="pause_until"')
@@ -152,8 +153,6 @@ test('pause form state and errors are cleared when reopening or cancelling a pau
     $component = Livewire::test('devices.manage')
         ->assertSeeHtml('wire:click="resetPauseForm"');
 
-    expect(mb_substr_count($component->html(), 'wire:click="resetPauseForm"'))->toBe(2);
-
     $component
         ->set('pause_duration', 'specific_date')
         ->set('pause_until', null)
@@ -172,6 +171,7 @@ test('user can pause a device using each fixed preset', function (int $minutes):
     Carbon::setTestNow('2026-01-15 10:00:00');
 
     Livewire::test('devices.manage')
+        ->set('pause_until', '2126-01-15T12:30')
         ->set('pause_duration', (string) $minutes)
         ->call('pauseDevice', $device->id)
         ->assertHasNoErrors()
@@ -251,6 +251,8 @@ test('invalid specific pause values leave the device unchanged', function (?stri
 })->with([
     'missing date' => null,
     'malformed date' => '2026-1-15T12:30',
+    'seconds are not accepted' => '2026-01-15T12:30:45',
+    'calendar values outside range' => '2026-99-99T99:99',
     'nonexistent Amsterdam spring-forward time' => '2026-03-29T02:30',
 ]);
 

--- a/tests/Feature/Devices/ManageTest.php
+++ b/tests/Feature/Devices/ManageTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\Device;
 use App\Models\User;
+use Carbon\Carbon;
 
 uses(Illuminate\Foundation\Testing\RefreshDatabase::class);
 
@@ -102,4 +103,157 @@ test('user cannot toggle proxy cloud for other users devices', function (): void
 
     $response->assertStatus(403);
     expect($device->fresh()->proxy_cloud)->toBeFalse();
+});
+
+test('pause modal keeps the fixed presets and offers a specific date and time', function (): void {
+    $user = User::factory()->create(['timezone' => 'Europe/Amsterdam']);
+    Device::factory()->create(['user_id' => $user->id]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->assertSee(['30 min', '60 min', '120 min', '240 min', '480 min'])
+        ->assertSee('Specific date and time')
+        ->set('pause_duration', 'specific_date')
+        ->assertSeeHtml('type="datetime-local"')
+        ->assertSee('Europe/Amsterdam');
+});
+
+test('user can pause a device using each fixed preset', function (int $minutes): void {
+    $user = User::factory()->create();
+    $device = Device::factory()->create(['user_id' => $user->id]);
+    $this->actingAs($user);
+    Carbon::setTestNow('2026-01-15 10:00:00');
+
+    Livewire::test('devices.manage')
+        ->set('pause_duration', (string) $minutes)
+        ->call('pauseDevice', $device->id)
+        ->assertHasNoErrors()
+        ->assertSet('pause_duration', null)
+        ->assertSet('pause_until', null);
+
+    expect($device->fresh()->pause_until->equalTo(now()->addMinutes($minutes)))->toBeTrue();
+
+    Carbon::setTestNow();
+})->with([
+    '30 minutes' => 30,
+    '60 minutes' => 60,
+    '120 minutes' => 120,
+    '240 minutes' => 240,
+    '480 minutes' => 480,
+]);
+
+test('specific pause dates are persisted as the intended user-timezone instant', function (string $localTime, string $expectedUtc): void {
+    config(['app.timezone' => 'UTC']);
+    Carbon::setTestNow('2026-01-01 00:00:00 UTC');
+    $user = User::factory()->create(['timezone' => 'Europe/Amsterdam']);
+    $device = Device::factory()->create(['user_id' => $user->id]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->set('pause_duration', 'specific_date')
+        ->set('pause_until', $localTime)
+        ->call('pauseDevice', $device->id)
+        ->assertHasNoErrors();
+
+    expect($device->fresh()->pause_until->utc()->format('Y-m-d H:i:s'))->toBe($expectedUtc);
+
+    Carbon::setTestNow();
+})->with([
+    'Amsterdam winter time' => ['2026-01-15T12:30', '2026-01-15 11:30:00'],
+    'Amsterdam summer time' => ['2026-07-15T12:30', '2026-07-15 10:30:00'],
+]);
+
+test('specific pause dates use the app timezone when the user has none', function (): void {
+    $originalTimezone = date_default_timezone_get();
+    config(['app.timezone' => 'America/New_York']);
+    date_default_timezone_set('America/New_York');
+    Carbon::setTestNow('2026-01-01 00:00:00 UTC');
+    $user = User::factory()->create(['timezone' => null]);
+    $device = Device::factory()->create(['user_id' => $user->id]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->set('pause_duration', 'specific_date')
+        ->set('pause_until', '2026-01-15T12:30')
+        ->call('pauseDevice', $device->id)
+        ->assertHasNoErrors();
+
+    expect($device->fresh()->pause_until->utc()->format('Y-m-d H:i:s'))->toBe('2026-01-15 17:30:00');
+
+    Carbon::setTestNow();
+    date_default_timezone_set($originalTimezone);
+});
+
+test('invalid specific pause values leave the device unchanged', function (?string $pauseUntil): void {
+    config(['app.timezone' => 'UTC']);
+    Carbon::setTestNow('2026-01-01 00:00:00 UTC');
+    $user = User::factory()->create(['timezone' => 'Europe/Amsterdam']);
+    $sentinel = Carbon::parse('2026-02-01 00:00:00 UTC');
+    $device = Device::factory()->create(['user_id' => $user->id, 'pause_until' => $sentinel]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->set('pause_duration', 'specific_date')
+        ->set('pause_until', $pauseUntil)
+        ->call('pauseDevice', $device->id)
+        ->assertHasErrors(['pause_until']);
+
+    expect($device->fresh()->pause_until->equalTo($sentinel))->toBeTrue();
+
+    Carbon::setTestNow();
+})->with([
+    'missing date' => null,
+    'malformed date' => '2026-1-15T12:30',
+    'nonexistent Amsterdam spring-forward time' => '2026-03-29T02:30',
+]);
+
+test('past and equal specific pause instants leave the device unchanged', function (string $pauseUntil): void {
+    config(['app.timezone' => 'UTC']);
+    Carbon::setTestNow('2026-01-15 12:30:00 UTC');
+    $user = User::factory()->create(['timezone' => 'UTC']);
+    $sentinel = Carbon::parse('2026-02-01 00:00:00 UTC');
+    $device = Device::factory()->create(['user_id' => $user->id, 'pause_until' => $sentinel]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->set('pause_duration', 'specific_date')
+        ->set('pause_until', $pauseUntil)
+        ->call('pauseDevice', $device->id)
+        ->assertHasErrors(['pause_until']);
+
+    expect($device->fresh()->pause_until->equalTo($sentinel))->toBeTrue();
+
+    Carbon::setTestNow();
+})->with([
+    'past' => '2026-01-15T12:29',
+    'equal to now' => '2026-01-15T12:30',
+]);
+
+test('unsupported pause selector leaves the device unchanged', function (): void {
+    $user = User::factory()->create();
+    $sentinel = Carbon::parse('2026-02-01 00:00:00 UTC');
+    $device = Device::factory()->create(['user_id' => $user->id, 'pause_until' => $sentinel]);
+    $this->actingAs($user);
+
+    Livewire::test('devices.manage')
+        ->set('pause_duration', '999')
+        ->call('pauseDevice', $device->id)
+        ->assertHasErrors(['pause_duration']);
+
+    expect($device->fresh()->pause_until->equalTo($sentinel))->toBeTrue();
+});
+
+test('user cannot pause another users device', function (): void {
+    $user = User::factory()->create();
+    $otherUser = User::factory()->create();
+    $sentinel = Carbon::parse('2026-02-01 00:00:00 UTC');
+    $device = Device::factory()->create(['user_id' => $otherUser->id, 'pause_until' => $sentinel]);
+    $this->actingAs($user);
+
+    expect(fn () => Livewire::test('devices.manage')
+        ->set('pause_duration', '30')
+        ->call('pauseDevice', $device->id))
+        ->toThrow(Illuminate\Database\Eloquent\ModelNotFoundException::class);
+
+    expect($device->fresh()->pause_until->equalTo($sentinel))->toBeTrue();
 });


### PR DESCRIPTION
## Summary

- add a specific date/time pause option while preserving the existing 30, 60, 120, 240, and 480 minute presets
- interpret custom values in the device owner's timezone, reject invalid/non-future input, and keep mutations owner-scoped
- keep returning the existing sleep image during an active pause while capping the device refresh interval at 24 hours
- show complete owner-local pause deadlines on both device management surfaces

## Context

Implements the maintainer-approved first iteration discussed in #276. This stays focused on choosing a specific future date and limiting server-directed refresh waits; indefinite pause, wake-to-resume, and sleep-screen configuration remain out of scope.

Closes #276.

## Testing

- `php artisan test`: 954 passed, 3,179 assertions
- focused manage pause coverage: 21 passed, 85 assertions
- focused display API pause coverage: 5 passed, 22 assertions
- focused configure tooltip coverage: 2 passed, 6 assertions
- Pint check across all six changed PHP/Blade files: passed
- Vite production build: passed
- `git diff --check`: passed
- PHPStan: no regression; the feature and untouched upstream baseline report the same 47 existing findings
- Claude Opus 5 maximum-effort adversarial review: `APPROVE` after closure review

## Scope

The PR contains only six application/test files. It adds no migration, dependency, API response field, local planning artifact, generated asset, or development harness file.